### PR TITLE
QA Bloque 2: seguridad backend, validaciones y consistencia

### DIFF
--- a/client/tests/e2e/regression.spec.ts
+++ b/client/tests/e2e/regression.spec.ts
@@ -3,7 +3,8 @@ import { test, expect } from '@playwright/test';
 test('auth routes preserve key headings and honest social login messaging', async ({ page }) => {
   await page.goto('/login');
   await expect(page.getByText(/google próximamente/i)).toBeVisible();
+  await expect(page.getByRole('heading', { level: 2, name: /^bienvenido\.$/i })).toBeVisible();
 
   await page.goto('/register');
-  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  await expect(page.getByRole('heading', { level: 2, name: /crea tu cuenta/i })).toBeVisible();
 });

--- a/client/tests/e2e/responsive.spec.ts
+++ b/client/tests/e2e/responsive.spec.ts
@@ -6,7 +6,7 @@ test('login route stays usable on a mobile viewport', async ({ browser }) => {
 
   await page.goto('http://127.0.0.1:4173/login');
 
-  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  await expect(page.getByRole('heading', { level: 2, name: /^bienvenido\.$/i })).toBeVisible();
   await expect(page.getByRole('button', { name: /iniciar sesión/i })).toBeVisible();
 
   await context.close();

--- a/client/tests/e2e/smoke.spec.ts
+++ b/client/tests/e2e/smoke.spec.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@playwright/test';
 test('login route loads core content', async ({ page }) => {
   await page.goto('/login');
 
-  await expect(page.getByRole('heading', { name: /bienvenido/i })).toBeVisible();
-  await expect(page.getByLabel(/correo electrónico/i)).toBeVisible();
+  await expect(page.getByRole('heading', { level: 2, name: /^bienvenido\.$/i })).toBeVisible();
+  await expect(page.getByLabel(/^email$/i)).toBeVisible();
 });

--- a/client/tests/unit/smoke/app.smoke.test.tsx
+++ b/client/tests/unit/smoke/app.smoke.test.tsx
@@ -10,6 +10,7 @@ describe('App smoke', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('heading', { level: 1, name: /^bienvenido$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /únete a la revolución urbana\./i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /^bienvenido\.$/i })).toBeInTheDocument();
   });
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.0",
         "express": "^4.18.2",
-        "jsonwebtoken": "^9.0.3"
+        "jsonwebtoken": "^9.0.3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
@@ -6979,6 +6980,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -20,18 +20,19 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "^9.0.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.29.0",
-    "@typescript-eslint/parser": "^8.29.0",
-    "@vitest/coverage-v8": "^3.1.1",
     "@types/bcrypt": "^5.0.0",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.11.0",
     "@types/supertest": "^6.0.3",
+    "@typescript-eslint/eslint-plugin": "^8.29.0",
+    "@typescript-eslint/parser": "^8.29.0",
+    "@vitest/coverage-v8": "^3.1.1",
     "autocannon": "^8.0.0",
     "eslint": "^8.57.1",
     "prisma": "^5.22.0",

--- a/server/src/config/jwt.ts
+++ b/server/src/config/jwt.ts
@@ -1,58 +1,67 @@
-import jwt, { SignOptions, Secret } from 'jsonwebtoken';
+import jwt, { type JwtPayload as JsonWebTokenPayload, type Secret, type SignOptions } from "jsonwebtoken";
 
-/**
- * Interfaz para el payload del JWT
- */
 export interface JwtPayload {
   id: string;
   email: string;
-  role: 'CLIENT' | 'ADMIN';
+  role: "CLIENT" | "ADMIN";
 }
 
 const JWT_SECRET: Secret =
   (process.env.JWT_SECRET as Secret) ||
-  ((process.env.NODE_ENV === 'test' ? 'test-secret-key' : undefined) as Secret);
+  ((process.env.NODE_ENV === "test" ? "test-secret-key" : undefined) as Secret);
+
 if (!JWT_SECRET) {
   throw new Error(
-    'CRITICAL: JWT_SECRET environment variable is not set. Authentication cannot start without it.'
+    "CRITICAL: JWT_SECRET environment variable is not set. Authentication cannot start without it."
   );
 }
-const JWT_EXPIRY: string = process.env.JWT_EXPIRY || '7d';
 
-/**
- * Generar un JWT para un usuario
- */
-export function generateToken(payload: JwtPayload): string {
-  const options: SignOptions = {
-    expiresIn: JWT_EXPIRY as any,
-  };
-  return jwt.sign(payload, JWT_SECRET, options);
+const JWT_EXPIRY = (process.env.JWT_EXPIRY || "7d") as SignOptions["expiresIn"];
+
+function isJwtPayload(value: string | JsonWebTokenPayload): value is JsonWebTokenPayload {
+  return typeof value !== "string";
 }
 
-/**
- * Verificar y decodificar un JWT
- */
+function isApplicationJwtPayload(payload: JsonWebTokenPayload): payload is JsonWebTokenPayload & JwtPayload {
+  return (
+    typeof payload.id === "string" &&
+    typeof payload.email === "string" &&
+    (payload.role === "CLIENT" || payload.role === "ADMIN")
+  );
+}
+
+export function generateToken(payload: JwtPayload): string {
+  return jwt.sign(payload, JWT_SECRET, {
+    expiresIn: JWT_EXPIRY,
+  });
+}
+
 export function verifyToken(token: string): JwtPayload | null {
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload;
-    return decoded;
-  } catch (error) {
-    console.error('[JWT] Verificación fallida:', error);
+    const decoded = jwt.verify(token, JWT_SECRET);
+
+    if (!isJwtPayload(decoded) || !isApplicationJwtPayload(decoded)) {
+      return null;
+    }
+
+    return {
+      id: decoded.id,
+      email: decoded.email,
+      role: decoded.role,
+    };
+  } catch (error: unknown) {
+    console.error("[JWT] Verificación fallida:", error);
     return null;
   }
 }
 
-/**
- * Extraer el token del header Authorization
- * Formato esperado: "Bearer <token>"
- */
 export function extractTokenFromHeader(authHeader?: string): string | null {
   if (!authHeader) {
     return null;
   }
 
-  const parts = authHeader.split(' ');
-  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer") {
     return null;
   }
 

--- a/server/src/controllers/authControllerLogin.ts
+++ b/server/src/controllers/authControllerLogin.ts
@@ -3,6 +3,7 @@ import { findUserByEmail, validatePassword } from "../services/userService";
 import { generateToken } from "../config/jwt";
 
 export const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DUMMY_PASSWORD_HASH = "$2b$10$svxwV3HOdQ0M/0lU8qN1OupgX2Y0W4tWQ0jY0H0N0tO3mM4c54Y1a";
 
 export function isValidEmail(email: string): boolean {
   return emailPattern.test(email);
@@ -23,12 +24,10 @@ export async function login(req: Request, res: Response): Promise<Response> {
 
   try {
     const user = await findUserByEmail(email.toLowerCase().trim());
-    if (!user) {
-      return res.status(401).json({ error: "Correo o contraseña incorrectos." });
-    }
+    const passwordHash = user?.password ?? DUMMY_PASSWORD_HASH;
+    const isValid = await validatePassword(password, passwordHash);
 
-    const isValid = await validatePassword(password, user.password);
-    if (!isValid) {
+    if (!user || !isValid) {
       return res.status(401).json({ error: "Correo o contraseña incorrectos." });
     }
 
@@ -49,7 +48,7 @@ export async function login(req: Request, res: Response): Promise<Response> {
         role: user.role,
       },
     });
-  } catch (err) {
+  } catch (err: unknown) {
     console.error("[login] Unexpected error:", err);
     return res.status(500).json({ error: "Error interno del servidor. Intenta más tarde." });
   }

--- a/server/src/controllers/authControllerRegister.ts
+++ b/server/src/controllers/authControllerRegister.ts
@@ -61,7 +61,7 @@ export async function register(req: Request, res: Response): Promise<Response> {
         role: user.role,
       },
     });
-  } catch (err) {
+  } catch (err: unknown) {
     // Prisma unique constraint fallback (race condition safety)
     if (
       err instanceof Prisma.PrismaClientKnownRequestError &&

--- a/server/src/controllers/authControllerRegister.ts
+++ b/server/src/controllers/authControllerRegister.ts
@@ -36,8 +36,8 @@ export async function register(req: Request, res: Response): Promise<Response> {
     // Duplicate email check
     const existing = await findUserByEmail(email.toLowerCase().trim());
     if (existing) {
-      return res.status(409).json({
-        error: "Ya existe una cuenta registrada con ese correo. Intenta iniciar sesión.",
+      return res.status(400).json({
+        error: "No se pudo completar el registro. Verifica los datos e intenta de nuevo o inicia sesión.",
       });
     }
 
@@ -67,8 +67,8 @@ export async function register(req: Request, res: Response): Promise<Response> {
       err instanceof Prisma.PrismaClientKnownRequestError &&
       err.code === "P2002"
     ) {
-      return res.status(409).json({
-        error: "Ya existe una cuenta registrada con ese correo. Intenta iniciar sesión.",
+      return res.status(400).json({
+        error: "No se pudo completar el registro. Verifica los datos e intenta de nuevo o inicia sesión.",
       });
     }
     console.error("[register] Unexpected error:", err);

--- a/server/src/controllers/orderController.ts
+++ b/server/src/controllers/orderController.ts
@@ -1,19 +1,17 @@
-import bcrypt from "bcrypt";
 import type { CartItem, Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 import prisma from "../config/prisma";
-import { extractTokenFromHeader, verifyToken } from "../config/jwt";
 import type { AuthenticatedRequest } from "../middlewares/auth";
-import { decrementProductStock, incrementProductStock, incrementVariantStock } from "../services/inventoryService";
+import { decrementProductStock, decrementVariantStock, incrementProductStock, incrementVariantStock } from "../services/inventoryService";
 
 type OrderItemPayload = {
   productId: number;
+  variantId?: number | null;
   quantity: number;
   price?: number;
 };
 
 type CreateOrderPayload = {
-  userId?: number;
   name: string;
   email: string;
   address: string;
@@ -27,6 +25,7 @@ type CreateOrderPayload = {
 
 type NormalizedOrderItem = {
   productId: number;
+  variantId: number | null;
   quantity: number;
 };
 
@@ -46,52 +45,26 @@ function isOrderError(error: unknown, code: (typeof ORDER_ERROR)[keyof typeof OR
   return error instanceof OrderError && error.code === code;
 }
 
-function parseAuthenticatedUserId(req: Request) {
-  const token = extractTokenFromHeader(req.headers.authorization);
-  if (!token) return null;
-
-  const payload = verifyToken(token);
-  if (!payload) return null;
-
-  const userId = Number(payload.id);
-  return Number.isNaN(userId) ? null : userId;
-}
-
-async function resolveOrderUserId(payload: CreateOrderPayload, authenticatedUserId: number | null) {
-  if (authenticatedUserId) {
-    return authenticatedUserId;
-  }
-
-  if (payload.userId && Number.isInteger(payload.userId) && payload.userId > 0) {
-    return payload.userId;
-  }
-
-  const existingUser = await prisma.user.findUnique({ where: { email: payload.email } });
-  if (existingUser) {
-    return existingUser.id;
-  }
-
-  const placeholderPassword = await bcrypt.hash(`checkout-${payload.email}`, 10);
-  const createdUser = await prisma.user.create({
-    data: {
-      name: payload.name,
-      email: payload.email,
-      password: placeholderPassword,
-      role: "CLIENT",
-    },
-  });
-
-  return createdUser.id;
-}
-
 function normalizeItems(items: OrderItemPayload[]): NormalizedOrderItem[] {
-  const aggregated = new Map<number, number>();
+  const aggregated = new Map<string, NormalizedOrderItem>();
 
   for (const item of items) {
-    aggregated.set(item.productId, (aggregated.get(item.productId) ?? 0) + item.quantity);
+    const variantId = item.variantId ?? null;
+    const key = `${item.productId}-${variantId}`;
+    const existing = aggregated.get(key);
+
+    if (existing) {
+      existing.quantity += item.quantity;
+    } else {
+      aggregated.set(key, {
+        productId: item.productId,
+        variantId,
+        quantity: item.quantity,
+      });
+    }
   }
 
-  return [...aggregated.entries()].map(([productId, quantity]) => ({ productId, quantity }));
+  return Array.from(aggregated.values());
 }
 
 async function restoreReservedCartStock(tx: Prisma.TransactionClient, cartItems: CartItem[]) {
@@ -107,23 +80,22 @@ async function restoreReservedCartStock(tx: Prisma.TransactionClient, cartItems:
 
 export async function createOrder(req: Request, res: Response) {
   try {
-    const payload = req.body as CreateOrderPayload;
-    const authenticatedUserId = parseAuthenticatedUserId(req);
-    const resolvedUserId = await resolveOrderUserId(payload, authenticatedUserId);
+    const authReq = req as AuthenticatedRequest;
+    const authenticatedUserId = Number(authReq.userId);
 
-    if (!resolvedUserId) {
-      throw new OrderError(ORDER_ERROR.USER_RESOLUTION_FAILED);
+    if (!Number.isInteger(authenticatedUserId) || authenticatedUserId <= 0) {
+      res.status(401).json({ success: false, message: "Usuario no autenticado" });
+      return;
     }
 
+    const payload = req.body as CreateOrderPayload;
     const normalizedItems = normalizeItems(payload.items);
 
     const order = await prisma.$transaction(async (tx) => {
-      const cart = authenticatedUserId
-        ? await tx.cart.findUnique({
-            where: { userId: authenticatedUserId },
-            include: { items: true },
-          })
-        : null;
+      const cart = await tx.cart.findUnique({
+        where: { userId: authenticatedUserId },
+        include: { items: true },
+      });
 
       if (cart?.items.length) {
         await restoreReservedCartStock(tx, cart.items);
@@ -148,13 +120,20 @@ export async function createOrder(req: Request, res: Response) {
           throw new OrderError(ORDER_ERROR.PRODUCT_NOT_FOUND);
         }
 
-        const decremented = await decrementProductStock(tx, item.productId, item.quantity);
+        let decremented = false;
+        if (item.variantId) {
+          decremented = await decrementVariantStock(tx, item.variantId, item.productId, item.quantity);
+        } else {
+          decremented = await decrementProductStock(tx, item.productId, item.quantity);
+        }
+
         if (!decremented) {
           throw new OrderError(ORDER_ERROR.INSUFFICIENT_STOCK);
         }
 
         authoritativeItems.push({
           productId: item.productId,
+          variantId: item.variantId,
           quantity: item.quantity,
           price: product.price,
         });
@@ -164,7 +143,7 @@ export async function createOrder(req: Request, res: Response) {
 
       const createdOrder = await tx.order.create({
         data: {
-          userId: resolvedUserId,
+          userId: authenticatedUserId,
           name: payload.name,
           email: payload.email,
           address: payload.address,
@@ -195,7 +174,7 @@ export async function createOrder(req: Request, res: Response) {
         },
       });
 
-      if (authenticatedUserId && cart) {
+      if (cart) {
         await tx.cartItem.deleteMany({ where: { cartId: cart.id } });
         await tx.cart.update({ where: { id: cart.id }, data: { total: 0 } });
       }
@@ -205,11 +184,6 @@ export async function createOrder(req: Request, res: Response) {
 
     res.status(201).json({ success: true, order });
   } catch (error: unknown) {
-    if (isOrderError(error, ORDER_ERROR.USER_RESOLUTION_FAILED)) {
-      res.status(400).json({ success: false, message: "No se pudo resolver el usuario de la orden" });
-      return;
-    }
-
     if (isOrderError(error, ORDER_ERROR.PRODUCT_NOT_FOUND)) {
       res.status(400).json({ success: false, message: "Uno o más productos ya no existen" });
       return;

--- a/server/src/controllers/orderController.ts
+++ b/server/src/controllers/orderController.ts
@@ -1,26 +1,50 @@
 import bcrypt from "bcrypt";
-import { Request, Response } from "express";
+import type { CartItem, Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
 import prisma from "../config/prisma";
 import { extractTokenFromHeader, verifyToken } from "../config/jwt";
+import type { AuthenticatedRequest } from "../middlewares/auth";
+import { decrementProductStock, incrementProductStock, incrementVariantStock } from "../services/inventoryService";
 
 type OrderItemPayload = {
   productId: number;
   quantity: number;
-  price: number;
+  price?: number;
 };
 
 type CreateOrderPayload = {
   userId?: number;
-  name?: string;
-  email?: string;
-  address?: string;
-  city?: string;
-  country?: string;
-  postalCode?: string;
-  phone?: string;
-  paymentMethod?: string;
-  items?: OrderItemPayload[];
+  name: string;
+  email: string;
+  address: string;
+  city: string;
+  country: string;
+  postalCode: string;
+  phone: string;
+  paymentMethod: string;
+  items: OrderItemPayload[];
 };
+
+type NormalizedOrderItem = {
+  productId: number;
+  quantity: number;
+};
+
+const ORDER_ERROR = {
+  PRODUCT_NOT_FOUND: "PRODUCT_NOT_FOUND",
+  INSUFFICIENT_STOCK: "INSUFFICIENT_STOCK",
+  USER_RESOLUTION_FAILED: "USER_RESOLUTION_FAILED",
+} as const;
+
+class OrderError extends Error {
+  constructor(public readonly code: (typeof ORDER_ERROR)[keyof typeof ORDER_ERROR]) {
+    super(code);
+  }
+}
+
+function isOrderError(error: unknown, code: (typeof ORDER_ERROR)[keyof typeof ORDER_ERROR]) {
+  return error instanceof OrderError && error.code === code;
+}
 
 function parseAuthenticatedUserId(req: Request) {
   const token = extractTokenFromHeader(req.headers.authorization);
@@ -42,23 +66,16 @@ async function resolveOrderUserId(payload: CreateOrderPayload, authenticatedUser
     return payload.userId;
   }
 
-  const email = payload.email?.trim().toLowerCase();
-  const name = payload.name?.trim();
-
-  if (!email || !name) {
-    return null;
-  }
-
-  const existingUser = await prisma.user.findUnique({ where: { email } });
+  const existingUser = await prisma.user.findUnique({ where: { email: payload.email } });
   if (existingUser) {
     return existingUser.id;
   }
 
-  const placeholderPassword = await bcrypt.hash(`checkout-${email}`, 10);
+  const placeholderPassword = await bcrypt.hash(`checkout-${payload.email}`, 10);
   const createdUser = await prisma.user.create({
     data: {
-      name,
-      email,
+      name: payload.name,
+      email: payload.email,
       password: placeholderPassword,
       role: "CLIENT",
     },
@@ -67,80 +84,99 @@ async function resolveOrderUserId(payload: CreateOrderPayload, authenticatedUser
   return createdUser.id;
 }
 
+function normalizeItems(items: OrderItemPayload[]): NormalizedOrderItem[] {
+  const aggregated = new Map<number, number>();
+
+  for (const item of items) {
+    aggregated.set(item.productId, (aggregated.get(item.productId) ?? 0) + item.quantity);
+  }
+
+  return [...aggregated.entries()].map(([productId, quantity]) => ({ productId, quantity }));
+}
+
+async function restoreReservedCartStock(tx: Prisma.TransactionClient, cartItems: CartItem[]) {
+  for (const item of cartItems) {
+    if (item.variantId) {
+      await incrementVariantStock(tx, item.variantId, item.quantity);
+      continue;
+    }
+
+    await incrementProductStock(tx, item.productId, item.quantity);
+  }
+}
+
 export async function createOrder(req: Request, res: Response) {
   try {
     const payload = req.body as CreateOrderPayload;
-    const { name, email, address, city, country, postalCode, phone, paymentMethod } = payload;
-    const items = Array.isArray(payload.items) ? payload.items : [];
-
-    if (!name || !email || !address || !city || !country || !postalCode || !phone || !paymentMethod) {
-      res.status(400).json({ success: false, message: "Faltan datos obligatorios de la orden" });
-      return;
-    }
-
-    if (items.length === 0) {
-      res.status(400).json({ success: false, message: "La orden debe incluir productos" });
-      return;
-    }
-
-    const normalizedItems = items.map((item) => ({
-      productId: Number(item.productId),
-      quantity: Number(item.quantity),
-      price: Number(item.price),
-    }));
-
-    const hasInvalidItem = normalizedItems.some(
-      (item) =>
-        Number.isNaN(item.productId) ||
-        item.productId <= 0 ||
-        !Number.isInteger(item.quantity) ||
-        item.quantity <= 0 ||
-        Number.isNaN(item.price) ||
-        item.price < 0
-    );
-
-    if (hasInvalidItem) {
-      res.status(400).json({ success: false, message: "Los productos de la orden no son válidos" });
-      return;
-    }
-
     const authenticatedUserId = parseAuthenticatedUserId(req);
     const resolvedUserId = await resolveOrderUserId(payload, authenticatedUserId);
 
     if (!resolvedUserId) {
-      res.status(400).json({ success: false, message: "No se pudo resolver el usuario de la orden" });
-      return;
+      throw new OrderError(ORDER_ERROR.USER_RESOLUTION_FAILED);
     }
 
-    const uniqueProductIds = [...new Set(normalizedItems.map((item) => item.productId))];
-    const products = await prisma.product.findMany({
-      where: { id: { in: uniqueProductIds } },
-      select: { id: true },
-    });
-
-    if (products.length !== uniqueProductIds.length) {
-      res.status(400).json({ success: false, message: "Uno o más productos ya no existen" });
-      return;
-    }
-
-    const total = normalizedItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+    const normalizedItems = normalizeItems(payload.items);
 
     const order = await prisma.$transaction(async (tx) => {
+      const cart = authenticatedUserId
+        ? await tx.cart.findUnique({
+            where: { userId: authenticatedUserId },
+            include: { items: true },
+          })
+        : null;
+
+      if (cart?.items.length) {
+        await restoreReservedCartStock(tx, cart.items);
+      }
+
+      const uniqueProductIds = [...new Set(normalizedItems.map((item) => item.productId))];
+      const products = await tx.product.findMany({
+        where: { id: { in: uniqueProductIds } },
+        select: { id: true, price: true },
+      });
+
+      if (products.length !== uniqueProductIds.length) {
+        throw new OrderError(ORDER_ERROR.PRODUCT_NOT_FOUND);
+      }
+
+      const productsById = new Map(products.map((product) => [product.id, product]));
+      const authoritativeItems = [] as Array<NormalizedOrderItem & { price: number }>;
+
+      for (const item of normalizedItems) {
+        const product = productsById.get(item.productId);
+        if (!product) {
+          throw new OrderError(ORDER_ERROR.PRODUCT_NOT_FOUND);
+        }
+
+        const decremented = await decrementProductStock(tx, item.productId, item.quantity);
+        if (!decremented) {
+          throw new OrderError(ORDER_ERROR.INSUFFICIENT_STOCK);
+        }
+
+        authoritativeItems.push({
+          productId: item.productId,
+          quantity: item.quantity,
+          price: product.price,
+        });
+      }
+
+      const total = authoritativeItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
       const createdOrder = await tx.order.create({
         data: {
           userId: resolvedUserId,
-          name: name.trim(),
-          email: email.trim().toLowerCase(),
-          address: address.trim(),
-          city: city.trim(),
-          country: country.trim(),
-          postalCode: postalCode.trim(),
-          phone: phone.trim(),
-          paymentMethod: paymentMethod.trim(),
+          name: payload.name,
+          email: payload.email,
+          address: payload.address,
+          city: payload.city,
+          country: payload.country,
+          postalCode: payload.postalCode,
+          phone: payload.phone,
+          paymentMethod: payload.paymentMethod,
           total,
           status: "pendiente",
           items: {
-            create: normalizedItems.map((item) => ({
+            create: authoritativeItems.map((item) => ({
               productId: item.productId,
               quantity: item.quantity,
               price: item.price,
@@ -159,27 +195,46 @@ export async function createOrder(req: Request, res: Response) {
         },
       });
 
-      if (authenticatedUserId) {
-        const cart = await tx.cart.findUnique({ where: { userId: authenticatedUserId } });
-        if (cart) {
-          await tx.cartItem.deleteMany({ where: { cartId: cart.id } });
-          await tx.cart.update({ where: { id: cart.id }, data: { total: 0 } });
-        }
+      if (authenticatedUserId && cart) {
+        await tx.cartItem.deleteMany({ where: { cartId: cart.id } });
+        await tx.cart.update({ where: { id: cart.id }, data: { total: 0 } });
       }
 
       return createdOrder;
     });
 
     res.status(201).json({ success: true, order });
-  } catch (error) {
+  } catch (error: unknown) {
+    if (isOrderError(error, ORDER_ERROR.USER_RESOLUTION_FAILED)) {
+      res.status(400).json({ success: false, message: "No se pudo resolver el usuario de la orden" });
+      return;
+    }
+
+    if (isOrderError(error, ORDER_ERROR.PRODUCT_NOT_FOUND)) {
+      res.status(400).json({ success: false, message: "Uno o más productos ya no existen" });
+      return;
+    }
+
+    if (isOrderError(error, ORDER_ERROR.INSUFFICIENT_STOCK)) {
+      res.status(400).json({ success: false, message: "Stock insuficiente para completar la orden" });
+      return;
+    }
+
     console.error("[orders:create]", error);
     res.status(500).json({ success: false, message: "Error al crear la orden" });
   }
 }
 
-export async function getOrders(_req: Request, res: Response) {
+export async function getOrders(req: AuthenticatedRequest, res: Response) {
   try {
+    const authenticatedUserId = Number(req.userId);
+    if (!Number.isInteger(authenticatedUserId) || authenticatedUserId <= 0) {
+      res.status(401).json({ success: false, message: "Usuario no autenticado" });
+      return;
+    }
+
     const orders = await prisma.order.findMany({
+      where: { userId: authenticatedUserId },
       orderBy: { createdAt: "desc" },
       include: {
         items: {
@@ -198,7 +253,7 @@ export async function getOrders(_req: Request, res: Response) {
     });
 
     res.json({ success: true, orders });
-  } catch (error) {
+  } catch (error: unknown) {
     console.error("[orders:list]", error);
     res.status(500).json({ success: false, message: "Error al obtener órdenes" });
   }

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,6 +1,6 @@
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { createError } from "./errorHandler";
-import { verifyToken, extractTokenFromHeader, JwtPayload } from "../config/jwt";
+import { verifyToken, extractTokenFromHeader, type JwtPayload } from "../config/jwt";
 
 /**
  * Interfaz extendida de Request con datos de usuario
@@ -43,7 +43,7 @@ export const authenticateToken = (
     req.userId = decoded.id;
 
     next();
-  } catch (error: any) {
+  } catch (error: unknown) {
     next(error);
   }
 };
@@ -53,7 +53,7 @@ export const authenticateToken = (
  * Especifica los roles permitidos y rechaza otros
  */
 export const authorizeRole = (allowedRoles: string[]) => {
-  return (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  return (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
     try {
       const userRole = req.user?.role;
 
@@ -66,7 +66,7 @@ export const authorizeRole = (allowedRoles: string[]) => {
       }
 
       next();
-    } catch (error: any) {
+    } catch (error: unknown) {
       next(error);
     }
   };
@@ -77,7 +77,7 @@ export const authorizeRole = (allowedRoles: string[]) => {
  */
 export const guestOnly = (
   req: AuthenticatedRequest,
-  res: Response,
+  _res: Response,
   next: NextFunction
 ) => {
   try {
@@ -94,7 +94,7 @@ export const guestOnly = (
     }
 
     next();
-  } catch (error: any) {
+  } catch (error: unknown) {
     next(error);
   }
 };

--- a/server/src/middlewares/errorHandler.ts
+++ b/server/src/middlewares/errorHandler.ts
@@ -1,11 +1,11 @@
-import { Request, Response, NextFunction } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 /**
  * Interfaz personalizada para errores de la aplicación
  */
 interface AppError extends Error {
   statusCode?: number;
-  details?: any;
+  details?: unknown;
 }
 
 /**
@@ -44,7 +44,7 @@ export const errorHandler = (
  * Úsalo así: router.post('/ruta', asyncHandler(async (req, res) => { ... }))
  */
 export const asyncHandler = (
-  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>
 ) => {
   return (req: Request, res: Response, next: NextFunction) => {
     Promise.resolve(fn(req, res, next)).catch(next);
@@ -57,7 +57,7 @@ export const asyncHandler = (
 export const createError = (
   message: string,
   statusCode: number = 500,
-  details?: any
+  details?: unknown
 ): AppError => {
   const error = new Error(message) as AppError;
   error.statusCode = statusCode;

--- a/server/src/middlewares/logger.ts
+++ b/server/src/middlewares/logger.ts
@@ -30,10 +30,10 @@ const getStatusColor = (statusCode: number): string => {
  */
 export const logger = (req: Request, res: Response, next: NextFunction) => {
   const startTime = Date.now();
-  const originalSend = res.send;
+  const originalSend = res.send.bind(res) as Response["send"];
 
   // Interceptar el envío de respuesta
-  res.send = function (data: any) {
+  res.send = ((data: unknown) => {
     const duration = Date.now() - startTime;
     const statusColor = getStatusColor(res.statusCode);
 
@@ -46,8 +46,8 @@ export const logger = (req: Request, res: Response, next: NextFunction) => {
       console.log(`  Body: ${JSON.stringify(req.body)}`);
     }
 
-    return originalSend.call(this, data);
-  };
+    return originalSend(data);
+  }) as Response["send"];
 
   next();
 };

--- a/server/src/middlewares/rateLimiter.ts
+++ b/server/src/middlewares/rateLimiter.ts
@@ -111,7 +111,7 @@ export const rateLimiter = (maxRequests: number = 100, windowMs: number = 60000)
       res.set("X-RateLimit-Reset", String(entry.resetTime));
 
       next();
-    } catch (error: any) {
+    } catch (error: unknown) {
       next(error);
     }
   };
@@ -122,6 +122,6 @@ export const rateLimiter = (maxRequests: number = 100, windowMs: number = 60000)
  * @param maxRequests Número máximo de solicitudes
  * @param windowMs Ventana de tiempo
  */
-export const authRateLimiter = (maxRequests: number = 100, windowMs: number = 120000) => {
+export const authRateLimiter = (maxRequests: number = 5, windowMs: number = 15 * 60 * 1000) => {
   return rateLimiter(maxRequests, windowMs);
 };

--- a/server/src/middlewares/validation.ts
+++ b/server/src/middlewares/validation.ts
@@ -1,204 +1,339 @@
-import { Request, Response, NextFunction } from "express";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { z, ZodError, type ZodType } from "zod";
 import { createError } from "./errorHandler";
 
-/**
- * Interfaz para reglas de validación
- */
-interface ValidationRule {
-  required?: boolean;
-  type?: "string" | "email" | "number" | "boolean";
-  minLength?: number;
-  maxLength?: number;
-  pattern?: RegExp;
-  custom?: (value: any) => boolean | Promise<boolean>;
-  message?: string;
-}
-
-/**
- * Interfaz para esquema de validación
- */
-interface ValidationSchema {
-  [key: string]: ValidationRule;
-}
-
-/**
- * Valida un email
- */
-const isValidEmail = (email: string): boolean => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(email);
+type RequestSchema = {
+  body?: ZodType;
+  params?: ZodType;
+  query?: ZodType;
 };
 
-/**
- * Valida un campo contra una regla de validación
- */
-const validateField = (
-  value: any,
-  fieldName: string,
-  rule: ValidationRule
-): { valid: boolean; error?: string } => {
-  // Validar requerimiento
-  if (rule.required && (value === undefined || value === null || value === "")) {
-    return {
-      valid: false,
-      error: rule.message || `${fieldName} es requerido`,
-    };
-  }
+const ORDER_STATUS = {
+  PENDIENTE: "pendiente",
+  PAGADO: "pagado",
+  ENVIADO: "enviado",
+  ENTREGADO: "entregado",
+  CANCELADO: "cancelado",
+} as const;
 
-  if (value === undefined || value === null || value === "") {
-    return { valid: true };
-  }
+const PAYMENT_METHOD = {
+  TARJETA: "tarjeta",
+  PAYPAL: "paypal",
+} as const;
 
-  // Validar tipo
-  if (rule.type) {
-    if (rule.type === "email") {
-      if (!isValidEmail(String(value))) {
-        return {
-          valid: false,
-          error: rule.message || `${fieldName} debe ser un email válido`,
-        };
-      }
-    } else if (typeof value !== rule.type) {
-      return {
-        valid: false,
-        error:
-          rule.message ||
-          `${fieldName} debe ser de tipo ${rule.type}, recibido ${typeof value}`,
-      };
+const orderStatusValues = [
+  ORDER_STATUS.PENDIENTE,
+  ORDER_STATUS.PAGADO,
+  ORDER_STATUS.ENVIADO,
+  ORDER_STATUS.ENTREGADO,
+  ORDER_STATUS.CANCELADO,
+] as const;
+
+const paymentMethodValues = [PAYMENT_METHOD.TARJETA, PAYMENT_METHOD.PAYPAL] as const;
+
+const integerIdSchema = z.coerce.number().int().positive();
+const trimmedStringSchema = z.string().trim();
+const optionalTrimmedStringSchema = z.string().trim().min(1).optional();
+const nullableTrimmedStringSchema = z.string().trim().min(1).nullable().optional();
+
+const normalizedEmailSchema = z.string().trim().toLowerCase().email();
+const passwordSchema = z.string().min(8).max(200);
+const normalizedOrderStatusSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value.trim().toLowerCase() : value),
+  z.enum(orderStatusValues)
+);
+const normalizedPaymentMethodSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value.trim().toLowerCase() : value),
+  z.enum(paymentMethodValues)
+);
+
+const loginSchema = z
+  .object({
+    email: normalizedEmailSchema,
+    password: passwordSchema,
+  })
+  .strict();
+
+const registerSchema = z
+  .object({
+    name: trimmedStringSchema.min(2).max(100),
+    email: normalizedEmailSchema,
+    password: passwordSchema,
+  })
+  .strict();
+
+const cartItemBodySchema = z
+  .object({
+    productId: integerIdSchema,
+    quantity: z.coerce.number().int().positive().max(100),
+    variantId: integerIdSchema.nullable().optional(),
+    color: nullableTrimmedStringSchema,
+    size: nullableTrimmedStringSchema,
+  })
+  .strict();
+
+const cartItemQuantityBodySchema = z
+  .object({
+    quantity: z.coerce.number().int().positive().max(100),
+  })
+  .strict();
+
+const orderItemSchema = z
+  .object({
+    productId: integerIdSchema,
+    quantity: z.coerce.number().int().positive().max(100),
+    price: z.coerce.number().nonnegative().optional(),
+  })
+  .strict();
+
+const orderBodySchema = z
+  .object({
+    userId: integerIdSchema.optional(),
+    name: trimmedStringSchema.min(2).max(100),
+    email: normalizedEmailSchema,
+    address: trimmedStringSchema.min(5).max(200),
+    city: trimmedStringSchema.min(2).max(100),
+    country: trimmedStringSchema.min(2).max(100),
+    postalCode: trimmedStringSchema.min(3).max(20),
+    phone: trimmedStringSchema.min(7).max(25),
+    paymentMethod: normalizedPaymentMethodSchema,
+    items: z.array(orderItemSchema).min(1).max(100),
+  })
+  .strict();
+
+const productIdParamsSchema = z
+  .object({
+    id: integerIdSchema,
+  })
+  .strict();
+
+const categorySlugParamsSchema = z
+  .object({
+    slug: trimmedStringSchema.min(1).max(100),
+  })
+  .strict();
+
+const productQuerySchema = z
+  .object({
+    categoryId: integerIdSchema.optional(),
+    search: optionalTrimmedStringSchema,
+    minPrice: z.coerce.number().nonnegative().optional(),
+    maxPrice: z.coerce.number().nonnegative().optional(),
+    featured: z
+      .enum(["true", "false"])
+      .transform((value) => value === "true")
+      .optional(),
+    page: z.coerce.number().int().positive().max(1000).default(1),
+    limit: z.coerce.number().int().positive().max(50).default(12),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.minPrice === undefined ||
+      value.maxPrice === undefined ||
+      value.minPrice <= value.maxPrice,
+    {
+      message: "minPrice no puede ser mayor que maxPrice",
+      path: ["minPrice"],
     }
-  }
+  );
 
-  // Validar longitud mínima
-  if (rule.minLength !== undefined && String(value).length < rule.minLength) {
-    return {
-      valid: false,
-      error:
-        rule.message ||
-        `${fieldName} debe tener mínimo ${rule.minLength} caracteres`,
-    };
-  }
+const productCreateBodySchema = z
+  .object({
+    name: trimmedStringSchema.min(2).max(120),
+    description: nullableTrimmedStringSchema,
+    price: z.coerce.number().nonnegative(),
+    comparePrice: z.coerce.number().nonnegative().nullable().optional(),
+    imageUrl: trimmedStringSchema.url().max(500),
+    stock: z.coerce.number().int().nonnegative().default(0),
+    featured: z.coerce.boolean().default(false),
+    badge: nullableTrimmedStringSchema,
+    categoryId: integerIdSchema,
+  })
+  .strict()
+  .refine(
+    (value) => value.comparePrice === undefined || value.comparePrice === null || value.comparePrice >= value.price,
+    {
+      message: "comparePrice debe ser mayor o igual a price",
+      path: ["comparePrice"],
+    }
+  );
 
-  // Validar longitud máxima
-  if (rule.maxLength !== undefined && String(value).length > rule.maxLength) {
-    return {
-      valid: false,
-      error:
-        rule.message ||
-        `${fieldName} debe tener máximo ${rule.maxLength} caracteres`,
-    };
-  }
+const productUpdateBodySchema = z
+  .object({
+    name: trimmedStringSchema.min(2).max(120).optional(),
+    description: z.string().trim().optional(),
+    price: z.coerce.number().nonnegative().optional(),
+    comparePrice: z.coerce.number().nonnegative().nullable().optional(),
+    imageUrl: trimmedStringSchema.url().max(500).optional(),
+    stock: z.coerce.number().int().nonnegative().optional(),
+    featured: z.coerce.boolean().optional(),
+    badge: z.string().trim().nullable().optional(),
+    categoryId: integerIdSchema.optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "Debes enviar al menos un campo para actualizar",
+  })
+  .refine(
+    (value) =>
+      value.comparePrice === undefined ||
+      value.comparePrice === null ||
+      value.price === undefined ||
+      value.comparePrice >= value.price,
+    {
+      message: "comparePrice debe ser mayor o igual a price",
+      path: ["comparePrice"],
+    }
+  );
 
-  // Validar patrón regex
-  if (rule.pattern && !rule.pattern.test(String(value))) {
-    return {
-      valid: false,
-      error:
-        rule.message || `${fieldName} tiene un formato inválido`,
-    };
-  }
+const categoryCreateBodySchema = z
+  .object({
+    name: trimmedStringSchema.min(2).max(100),
+    slug: trimmedStringSchema
+      .min(2)
+      .max(100)
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      .transform((slug) => slug.toLowerCase()),
+    imageUrl: z.string().trim().url().nullable().optional(),
+    description: nullableTrimmedStringSchema,
+  })
+  .strict();
 
-  return { valid: true };
-};
+const categoryUpdateBodySchema = z
+  .object({
+    name: trimmedStringSchema.min(2).max(100).optional(),
+    slug: trimmedStringSchema
+      .min(2)
+      .max(100)
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      .transform((slug) => slug.toLowerCase())
+      .optional(),
+    imageUrl: z.string().trim().url().optional(),
+    description: z.string().trim().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "Debes enviar al menos un campo para actualizar",
+  });
 
-/**
- * Middleware genérico para validar datos del request body
- * @param schema Esquema de validación
- * @returns Middleware de Express
- */
-export const validateRequest = (schema: ValidationSchema) => {
-  return (req: Request, res: Response, next: NextFunction) => {
+const adminPaginationQuerySchema = z
+  .object({
+    page: z.coerce.number().int().positive().max(1000).default(1),
+    limit: z.coerce.number().int().positive().max(100).default(20),
+  })
+  .strict();
+
+const adminOrdersQuerySchema = adminPaginationQuerySchema.extend({
+  status: normalizedOrderStatusSchema.optional(),
+});
+
+const adminOrderStatusBodySchema = z
+  .object({
+    status: normalizedOrderStatusSchema,
+  })
+  .strict();
+
+function flattenZodIssues(error: ZodError) {
+  return error.issues.reduce<Record<string, string>>((acc, issue) => {
+    const path = issue.path.join(".") || "root";
+    if (!acc[path]) {
+      acc[path] = issue.message;
+    }
+    return acc;
+  }, {});
+}
+
+export const validateRequest = (schema: RequestSchema): RequestHandler => {
+  return (req: Request, _res: Response, next: NextFunction) => {
     try {
-      const errors: Record<string, string> = {};
-
-      // Validar cada campo del esquema
-      for (const [fieldName, rule] of Object.entries(schema)) {
-        const value = req.body[fieldName];
-        const validation = validateField(value, fieldName, rule);
-
-        if (!validation.valid) {
-          errors[fieldName] = validation.error!;
-        }
+      if (schema.body) {
+        req.body = schema.body.parse(req.body);
       }
 
-      // Si hay errores, retornar respuesta de error
-      if (Object.keys(errors).length > 0) {
-        throw createError("Datos inválidos", 400, {
-          code: "VALIDATION_ERROR",
-          errors,
-        });
+      if (schema.params) {
+        req.params = schema.params.parse(req.params) as Request["params"];
+      }
+
+      if (schema.query) {
+        req.query = schema.query.parse(req.query) as Request["query"];
       }
 
       next();
-    } catch (error: any) {
+    } catch (error: unknown) {
+      if (error instanceof ZodError) {
+        next(
+          createError("Datos inválidos", 400, {
+            code: "VALIDATION_ERROR",
+            errors: flattenZodIssues(error),
+            issues: error.issues,
+          })
+        );
+        return;
+      }
+
       next(error);
     }
   };
 };
 
-/**
- * Middleware para validar solo la presencia de un campo
- */
-export const validateRequired = (fields: string[]) => {
-  return (req: Request, res: Response, next: NextFunction) => {
+export const validateRequired = (fields: string[]): RequestHandler => {
+  return (req: Request, _res: Response, next: NextFunction) => {
     try {
-      const errors: Record<string, string> = {};
-
-      fields.forEach((field) => {
-        if (!req.body[field]) {
-          errors[field] = `${field} es requerido`;
+      const errors = fields.reduce<Record<string, string>>((acc, field) => {
+        if (!req.body || req.body[field] === undefined || req.body[field] === null || req.body[field] === "") {
+          acc[field] = `${field} es requerido`;
         }
-      });
+
+        return acc;
+      }, {});
 
       if (Object.keys(errors).length > 0) {
-        throw createError("Campos requeridos faltantes", 400, {
-          code: "MISSING_REQUIRED_FIELDS",
-          errors,
-        });
+        next(
+          createError("Campos requeridos faltantes", 400, {
+            code: "MISSING_REQUIRED_FIELDS",
+            errors,
+          })
+        );
+        return;
       }
 
       next();
-    } catch (error: any) {
+    } catch (error: unknown) {
       next(error);
     }
   };
 };
 
-/**
- * Esquemas de validación predefinidos para casos comunes
- */
 export const validationSchemas = {
-  login: {
-    email: {
-      required: true,
-      type: "email" as const,
-      message: "Email válido requerido",
-    },
-    password: {
-      required: true,
-      type: "string" as const,
-      minLength: 8,
-      message: "Contraseña requerida (mínimo 8 caracteres)",
-    },
+  login: { body: loginSchema },
+  register: { body: registerSchema },
+  cart: {
+    addItem: { body: cartItemBodySchema },
+    updateItem: { params: productIdParamsSchema, body: cartItemQuantityBodySchema },
+    deleteItem: { params: productIdParamsSchema },
   },
-
-  register: {
-    email: {
-      required: true,
-      type: "email" as const,
-      message: "Email válido requerido",
-    },
-    password: {
-      required: true,
-      type: "string" as const,
-      minLength: 8,
-      message: "Contraseña requerida (mínimo 8 caracteres)",
-    },
-    name: {
-      required: true,
-      type: "string" as const,
-      minLength: 2,
-      maxLength: 100,
-      message: "Nombre válido requerido (2-100 caracteres)",
-    },
+  orders: {
+    create: { body: orderBodySchema },
+  },
+  products: {
+    list: { query: productQuerySchema },
+    byId: { params: productIdParamsSchema },
+    create: { body: productCreateBodySchema },
+    update: { params: productIdParamsSchema, body: productUpdateBodySchema },
+    remove: { params: productIdParamsSchema },
+  },
+  categories: {
+    bySlug: { params: categorySlugParamsSchema },
+    create: { body: categoryCreateBodySchema },
+    update: { params: productIdParamsSchema, body: categoryUpdateBodySchema },
+    remove: { params: productIdParamsSchema },
+  },
+  admin: {
+    listUsers: { query: adminPaginationQuerySchema },
+    listOrders: { query: adminOrdersQuerySchema },
+    updateOrderStatus: { params: productIdParamsSchema, body: adminOrderStatusBodySchema },
   },
 };
+
+export type ValidationSchemas = typeof validationSchemas;

--- a/server/src/middlewares/validation.ts
+++ b/server/src/middlewares/validation.ts
@@ -81,6 +81,7 @@ const cartItemQuantityBodySchema = z
 const orderItemSchema = z
   .object({
     productId: integerIdSchema,
+    variantId: integerIdSchema.nullable().optional(),
     quantity: z.coerce.number().int().positive().max(100),
     price: z.coerce.number().nonnegative().optional(),
   })
@@ -88,7 +89,6 @@ const orderItemSchema = z
 
 const orderBodySchema = z
   .object({
-    userId: integerIdSchema.optional(),
     name: trimmedStringSchema.min(2).max(100),
     email: normalizedEmailSchema,
     address: trimmedStringSchema.min(5).max(200),

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -5,15 +5,19 @@ import {
   getDashboardMetrics,
   updateAdminOrderStatus,
 } from "../controllers/adminController";
-import { authenticateToken, authorizeRole } from "../middlewares";
+import { authenticateToken, authorizeRole, validateRequest, validationSchemas } from "../middlewares";
 
 const router = Router();
 
 router.use(authenticateToken, authorizeRole(["ADMIN"]));
 
 router.get("/dashboard/metrics", getDashboardMetrics);
-router.get("/users", getAdminUsers);
-router.get("/orders", getAdminOrders);
-router.patch("/orders/:id/status", updateAdminOrderStatus);
+router.get("/users", validateRequest(validationSchemas.admin.listUsers), getAdminUsers);
+router.get("/orders", validateRequest(validationSchemas.admin.listOrders), getAdminOrders);
+router.patch(
+  "/orders/:id/status",
+  validateRequest(validationSchemas.admin.updateOrderStatus),
+  updateAdminOrderStatus
+);
 
 export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -11,13 +11,13 @@ import {
 import { AuthenticatedRequest } from "../middlewares/auth";
 
 const router = Router();
-const authRateLimitMaxRequests = Number(process.env.AUTH_RATE_LIMIT_MAX_REQUESTS) || 100;
-const authRateLimitWindowMs = Number(process.env.AUTH_RATE_LIMIT_WINDOW_MS) || 120000;
+const authRateLimitMaxRequests = Number(process.env.AUTH_RATE_LIMIT_MAX_REQUESTS) || 5;
+const authRateLimitWindowMs = Number(process.env.AUTH_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 
 /**
  * POST /api/auth/register
  * Registrar un nuevo usuario con validación de datos
- * Rate limited: 100 solicitudes por 2 minutos
+ * Rate limited: 5 solicitudes por 15 minutos
  */
 router.post(
   "/register",
@@ -29,7 +29,7 @@ router.post(
 /**
  * POST /api/auth/login
  * Login de usuario con validación de datos
- * Rate limited: 100 solicitudes por 2 minutos
+ * Rate limited: 5 solicitudes por 15 minutos
  */
 router.post(
   "/login",

--- a/server/src/routes/cart.ts
+++ b/server/src/routes/cart.ts
@@ -1,12 +1,39 @@
+import { Prisma } from "@prisma/client";
 import { Router } from "express";
 import prisma from "../config/prisma";
 import type { AuthenticatedRequest } from "../middlewares";
+import { validateRequest, validationSchemas } from "../middlewares";
+import {
+  decrementProductStock,
+  decrementVariantStock,
+  incrementProductStock,
+  incrementVariantStock,
+} from "../services/inventoryService";
 
 const router = Router();
+
+const CART_ERROR = {
+  PRODUCT_NOT_FOUND: "PRODUCT_NOT_FOUND",
+  VARIANT_NOT_FOUND: "VARIANT_NOT_FOUND",
+  INSUFFICIENT_STOCK: "INSUFFICIENT_STOCK",
+  ITEM_NOT_FOUND: "ITEM_NOT_FOUND",
+  ITEM_CONFLICT: "ITEM_CONFLICT",
+} as const;
+
+class CartError extends Error {
+  constructor(public readonly code: (typeof CART_ERROR)[keyof typeof CART_ERROR]) {
+    super(code);
+  }
+}
+
+function isCartError(error: unknown, code: (typeof CART_ERROR)[keyof typeof CART_ERROR]) {
+  return error instanceof CartError && error.code === code;
+}
 
 function parseUserId(req: AuthenticatedRequest): number | null {
   const raw = req.userId ?? req.user?.id;
   if (!raw) return null;
+
   const userId = Number(raw);
   return Number.isNaN(userId) ? null : userId;
 }
@@ -45,7 +72,7 @@ async function recalculateCartTotal(cartId: number) {
 }
 
 async function getCartResponse(cartId: number) {
-  const cart = await prisma.cart.findUnique({
+  return prisma.cart.findUnique({
     where: { id: cartId },
     include: {
       items: {
@@ -57,8 +84,6 @@ async function getCartResponse(cartId: number) {
       },
     },
   });
-
-  return cart;
 }
 
 router.get("/", async (req: AuthenticatedRequest, res) => {
@@ -73,88 +98,82 @@ router.get("/", async (req: AuthenticatedRequest, res) => {
     const response = await getCartResponse(cart.id);
 
     res.json({ success: true, data: response });
-  } catch (error) {
+  } catch (error: unknown) {
     console.error("[cart:get]", error);
     res.status(500).json({ success: false, error: "Error al obtener carrito" });
   }
 });
 
-router.post("/items", async (req: AuthenticatedRequest, res) => {
-  try {
-    const userId = parseUserId(req);
-    if (!userId) {
-      res.status(401).json({ success: false, error: "Usuario no autenticado" });
-      return;
-    }
-
-    const productId = Number(req.body?.productId);
-    const quantity = Number(req.body?.quantity ?? 1);
-    const variantId = req.body?.variantId !== undefined ? Number(req.body.variantId) : null;
-    const color = req.body?.color ? String(req.body.color).trim() : null;
-    const size = req.body?.size ? String(req.body.size).trim() : null;
-
-    if (Number.isNaN(productId) || productId <= 0) {
-      res.status(400).json({ success: false, error: "productId inválido" });
-      return;
-    }
-
-    if (!Number.isInteger(quantity) || quantity <= 0) {
-      res.status(400).json({ success: false, error: "quantity debe ser un entero mayor a 0" });
-      return;
-    }
-
-    const cart = await ensureUserCart(userId);
-
-    await prisma.$transaction(async (tx) => {
-      const product = await tx.product.findUnique({ where: { id: productId } });
-      if (!product) throw new Error("PRODUCT_NOT_FOUND");
-
-      let unitPrice = product.price;
-
-      if (variantId) {
-        const variant = await tx.productVariant.findFirst({
-          where: { id: variantId, productId },
-        });
-
-        if (!variant) throw new Error("VARIANT_NOT_FOUND");
-        if (variant.stock < quantity) throw new Error("INSUFFICIENT_STOCK");
-
-        unitPrice = variant.price;
-
-        await tx.productVariant.update({
-          where: { id: variant.id },
-          data: { stock: { decrement: quantity } },
-        });
-      } else {
-        if (product.stock < quantity) throw new Error("INSUFFICIENT_STOCK");
-
-        await tx.product.update({
-          where: { id: product.id },
-          data: { stock: { decrement: quantity } },
-        });
+router.post(
+  "/items",
+  validateRequest(validationSchemas.cart.addItem),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const userId = parseUserId(req);
+      if (!userId) {
+        res.status(401).json({ success: false, error: "Usuario no autenticado" });
+        return;
       }
 
-      const lineKey = buildLineKey({ productId, variantId, color, size });
-      const existing = await tx.cartItem.findUnique({
-        where: { cartId_lineKey: { cartId: cart.id, lineKey } },
-      });
+      const { productId, quantity, variantId, color, size } = req.body as {
+        productId: number;
+        quantity: number;
+        variantId?: number | null;
+        color?: string | null;
+        size?: string | null;
+      };
 
-      if (existing) {
-        const newQuantity = existing.quantity + quantity;
-        await tx.cartItem.update({
-          where: { id: existing.id },
-          data: {
-            quantity: newQuantity,
-            unitPrice,
-            subtotal: newQuantity * unitPrice,
-          },
+      const cart = await ensureUserCart(userId);
+
+      await prisma.$transaction(async (tx) => {
+        const product = await tx.product.findUnique({
+          where: { id: productId },
+          select: { id: true, price: true },
         });
-      } else {
-        await tx.cartItem.create({
-          data: {
+
+        if (!product) {
+          throw new CartError(CART_ERROR.PRODUCT_NOT_FOUND);
+        }
+
+        let unitPrice = product.price;
+
+        if (variantId) {
+          const variant = await tx.productVariant.findFirst({
+            where: { id: variantId, productId },
+            select: { id: true, productId: true, price: true },
+          });
+
+          if (!variant) {
+            throw new CartError(CART_ERROR.VARIANT_NOT_FOUND);
+          }
+
+          const reserved = await decrementVariantStock(tx, variant.id, productId, quantity);
+          if (!reserved) {
+            throw new CartError(CART_ERROR.INSUFFICIENT_STOCK);
+          }
+
+          unitPrice = variant.price;
+        } else {
+          const reserved = await decrementProductStock(tx, productId, quantity);
+          if (!reserved) {
+            throw new CartError(CART_ERROR.INSUFFICIENT_STOCK);
+          }
+        }
+
+        const lineKey = buildLineKey({ productId, variantId, color, size });
+        const upserted = await tx.cartItem.upsert({
+          where: { cartId_lineKey: { cartId: cart.id, lineKey } },
+          update: {
+            quantity: { increment: quantity },
+            unitPrice,
+            subtotal: { increment: quantity * unitPrice },
+            color,
+            size,
+          },
+          create: {
             cartId: cart.id,
             productId,
-            variantId,
+            variantId: variantId ?? null,
             lineKey,
             color,
             size,
@@ -163,176 +182,205 @@ router.post("/items", async (req: AuthenticatedRequest, res) => {
             subtotal: quantity * unitPrice,
           },
         });
-      }
-    });
 
-    await recalculateCartTotal(cart.id);
-    const response = await getCartResponse(cart.id);
-    res.status(201).json({ success: true, data: response });
-  } catch (error: any) {
-    if (error?.message === "PRODUCT_NOT_FOUND") {
-      res.status(404).json({ success: false, error: "Producto no encontrado" });
-      return;
-    }
-
-    if (error?.message === "VARIANT_NOT_FOUND") {
-      res.status(404).json({ success: false, error: "Variante no encontrada" });
-      return;
-    }
-
-    if (error?.message === "INSUFFICIENT_STOCK") {
-      res.status(400).json({ success: false, error: "Stock insuficiente" });
-      return;
-    }
-
-    console.error("[cart:add-item]", error);
-    res.status(500).json({ success: false, error: "Error al agregar ítem al carrito" });
-  }
-});
-
-router.patch("/items/:id", async (req: AuthenticatedRequest, res) => {
-  try {
-    const userId = parseUserId(req);
-    if (!userId) {
-      res.status(401).json({ success: false, error: "Usuario no autenticado" });
-      return;
-    }
-
-    const itemId = Number(req.params.id);
-    const quantity = Number(req.body?.quantity);
-
-    if (Number.isNaN(itemId) || itemId <= 0) {
-      res.status(400).json({ success: false, error: "itemId inválido" });
-      return;
-    }
-
-    if (!Number.isInteger(quantity) || quantity <= 0) {
-      res.status(400).json({ success: false, error: "quantity debe ser un entero mayor a 0" });
-      return;
-    }
-
-    const cart = await ensureUserCart(userId);
-
-    const existingItem = await prisma.cartItem.findFirst({
-      where: { id: itemId, cartId: cart.id },
-      include: { product: true, variant: true },
-    });
-
-    if (!existingItem) {
-      res.status(404).json({ success: false, error: "Ítem no encontrado" });
-      return;
-    }
-
-    const delta = quantity - existingItem.quantity;
-
-    await prisma.$transaction(async (tx) => {
-      if (delta > 0) {
-        if (existingItem.variantId) {
-          const variant = await tx.productVariant.findUnique({ where: { id: existingItem.variantId } });
-          if (!variant || variant.stock < delta) throw new Error("INSUFFICIENT_STOCK");
-
-          await tx.productVariant.update({
-            where: { id: variant.id },
-            data: { stock: { decrement: delta } },
-          });
-        } else {
-          const product = await tx.product.findUnique({ where: { id: existingItem.productId } });
-          if (!product || product.stock < delta) throw new Error("INSUFFICIENT_STOCK");
-
-          await tx.product.update({
-            where: { id: product.id },
-            data: { stock: { decrement: delta } },
+        const expectedSubtotal = upserted.quantity * unitPrice;
+        if (upserted.subtotal !== expectedSubtotal) {
+          await tx.cartItem.update({
+            where: { id: upserted.id },
+            data: { subtotal: expectedSubtotal },
           });
         }
-      }
-
-      if (delta < 0) {
-        const toRestore = Math.abs(delta);
-
-        if (existingItem.variantId) {
-          await tx.productVariant.update({
-            where: { id: existingItem.variantId },
-            data: { stock: { increment: toRestore } },
-          });
-        } else {
-          await tx.product.update({
-            where: { id: existingItem.productId },
-            data: { stock: { increment: toRestore } },
-          });
-        }
-      }
-
-      await tx.cartItem.update({
-        where: { id: existingItem.id },
-        data: {
-          quantity,
-          subtotal: quantity * existingItem.unitPrice,
-        },
       });
-    });
 
-    await recalculateCartTotal(cart.id);
-    const response = await getCartResponse(cart.id);
-    res.json({ success: true, data: response });
-  } catch (error: any) {
-    if (error?.message === "INSUFFICIENT_STOCK") {
-      res.status(400).json({ success: false, error: "Stock insuficiente" });
-      return;
-    }
-
-    console.error("[cart:update-item]", error);
-    res.status(500).json({ success: false, error: "Error al actualizar ítem" });
-  }
-});
-
-router.delete("/items/:id", async (req: AuthenticatedRequest, res) => {
-  try {
-    const userId = parseUserId(req);
-    if (!userId) {
-      res.status(401).json({ success: false, error: "Usuario no autenticado" });
-      return;
-    }
-
-    const itemId = Number(req.params.id);
-    if (Number.isNaN(itemId) || itemId <= 0) {
-      res.status(400).json({ success: false, error: "itemId inválido" });
-      return;
-    }
-
-    const cart = await ensureUserCart(userId);
-
-    const existingItem = await prisma.cartItem.findFirst({
-      where: { id: itemId, cartId: cart.id },
-    });
-
-    if (!existingItem) {
-      res.status(404).json({ success: false, error: "Ítem no encontrado" });
-      return;
-    }
-
-    await prisma.$transaction(async (tx) => {
-      if (existingItem.variantId) {
-        await tx.productVariant.update({
-          where: { id: existingItem.variantId },
-          data: { stock: { increment: existingItem.quantity } },
-        });
-      } else {
-        await tx.product.update({
-          where: { id: existingItem.productId },
-          data: { stock: { increment: existingItem.quantity } },
-        });
+      await recalculateCartTotal(cart.id);
+      const response = await getCartResponse(cart.id);
+      res.status(201).json({ success: true, data: response });
+    } catch (error: unknown) {
+      if (isCartError(error, CART_ERROR.PRODUCT_NOT_FOUND)) {
+        res.status(404).json({ success: false, error: "Producto no encontrado" });
+        return;
       }
 
-      await tx.cartItem.delete({ where: { id: existingItem.id } });
-    });
+      if (isCartError(error, CART_ERROR.VARIANT_NOT_FOUND)) {
+        res.status(404).json({ success: false, error: "Variante no encontrada" });
+        return;
+      }
 
-    await recalculateCartTotal(cart.id);
-    const response = await getCartResponse(cart.id);
-    res.json({ success: true, data: response });
-  } catch (error) {
-    console.error("[cart:delete-item]", error);
-    res.status(500).json({ success: false, error: "Error al eliminar ítem" });
+      if (isCartError(error, CART_ERROR.INSUFFICIENT_STOCK)) {
+        res.status(400).json({ success: false, error: "Stock insuficiente" });
+        return;
+      }
+
+      console.error("[cart:add-item]", error);
+      res.status(500).json({ success: false, error: "Error al agregar ítem al carrito" });
+    }
   }
-});
+);
+
+router.patch(
+  "/items/:id",
+  validateRequest(validationSchemas.cart.updateItem),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const userId = parseUserId(req);
+      if (!userId) {
+        res.status(401).json({ success: false, error: "Usuario no autenticado" });
+        return;
+      }
+
+      const itemId = Number(req.params.id);
+      const { quantity } = req.body as { quantity: number };
+      const cart = await ensureUserCart(userId);
+
+      await prisma.$transaction(async (tx) => {
+        const existingItem = await tx.cartItem.findFirst({
+          where: { id: itemId, cartId: cart.id },
+          select: {
+            id: true,
+            productId: true,
+            variantId: true,
+            quantity: true,
+            unitPrice: true,
+          },
+        });
+
+        if (!existingItem) {
+          throw new CartError(CART_ERROR.ITEM_NOT_FOUND);
+        }
+
+        const delta = quantity - existingItem.quantity;
+
+        if (delta > 0) {
+          if (existingItem.variantId) {
+            const reserved = await decrementVariantStock(
+              tx,
+              existingItem.variantId,
+              existingItem.productId,
+              delta
+            );
+
+            if (!reserved) {
+              throw new CartError(CART_ERROR.INSUFFICIENT_STOCK);
+            }
+          } else {
+            const reserved = await decrementProductStock(tx, existingItem.productId, delta);
+            if (!reserved) {
+              throw new CartError(CART_ERROR.INSUFFICIENT_STOCK);
+            }
+          }
+        }
+
+        if (delta < 0) {
+          const toRestore = Math.abs(delta);
+
+          if (existingItem.variantId) {
+            await incrementVariantStock(tx, existingItem.variantId, toRestore);
+          } else {
+            await incrementProductStock(tx, existingItem.productId, toRestore);
+          }
+        }
+
+        const updatedItem = await tx.cartItem.updateMany({
+          where: {
+            id: existingItem.id,
+            cartId: cart.id,
+            quantity: existingItem.quantity,
+          },
+          data: {
+            quantity,
+            subtotal: quantity * existingItem.unitPrice,
+          },
+        });
+
+        if (updatedItem.count !== 1) {
+          throw new CartError(CART_ERROR.ITEM_CONFLICT);
+        }
+      });
+
+      await recalculateCartTotal(cart.id);
+      const response = await getCartResponse(cart.id);
+      res.json({ success: true, data: response });
+    } catch (error: unknown) {
+      if (isCartError(error, CART_ERROR.ITEM_NOT_FOUND)) {
+        res.status(404).json({ success: false, error: "Ítem no encontrado" });
+        return;
+      }
+
+      if (isCartError(error, CART_ERROR.INSUFFICIENT_STOCK)) {
+        res.status(400).json({ success: false, error: "Stock insuficiente" });
+        return;
+      }
+
+      if (isCartError(error, CART_ERROR.ITEM_CONFLICT)) {
+        res.status(409).json({ success: false, error: "El carrito cambió, reintenta la operación" });
+        return;
+      }
+
+      console.error("[cart:update-item]", error);
+      res.status(500).json({ success: false, error: "Error al actualizar ítem" });
+    }
+  }
+);
+
+router.delete(
+  "/items/:id",
+  validateRequest(validationSchemas.cart.deleteItem),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const userId = parseUserId(req);
+      if (!userId) {
+        res.status(401).json({ success: false, error: "Usuario no autenticado" });
+        return;
+      }
+
+      const itemId = Number(req.params.id);
+      const cart = await ensureUserCart(userId);
+
+      await prisma.$transaction(async (tx) => {
+        const existingItem = await tx.cartItem.findFirst({
+          where: { id: itemId, cartId: cart.id },
+          select: {
+            id: true,
+            productId: true,
+            variantId: true,
+            quantity: true,
+          },
+        });
+
+        if (!existingItem) {
+          throw new CartError(CART_ERROR.ITEM_NOT_FOUND);
+        }
+
+        if (existingItem.variantId) {
+          await incrementVariantStock(tx, existingItem.variantId, existingItem.quantity);
+        } else {
+          await incrementProductStock(tx, existingItem.productId, existingItem.quantity);
+        }
+
+        await tx.cartItem.delete({ where: { id: existingItem.id } });
+      });
+
+      await recalculateCartTotal(cart.id);
+      const response = await getCartResponse(cart.id);
+      res.json({ success: true, data: response });
+    } catch (error: unknown) {
+      if (isCartError(error, CART_ERROR.ITEM_NOT_FOUND)) {
+        res.status(404).json({ success: false, error: "Ítem no encontrado" });
+        return;
+      }
+
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        res.status(404).json({ success: false, error: "Ítem no encontrado" });
+        return;
+      }
+
+      console.error("[cart:delete-item]", error);
+      res.status(500).json({ success: false, error: "Error al eliminar ítem" });
+    }
+  }
+);
 
 export default router;

--- a/server/src/routes/categories.ts
+++ b/server/src/routes/categories.ts
@@ -6,15 +6,33 @@ import {
   putCategory,
   removeCategory,
 } from "../controllers/categoryController";
-import { authenticateToken, authorizeRole } from "../middlewares";
+import { authenticateToken, authorizeRole, validateRequest, validationSchemas } from "../middlewares";
 
 const router = Router();
 
 router.get("/", getCategories);
-router.get("/:slug", getCategoryBySlug);
+router.get("/:slug", validateRequest(validationSchemas.categories.bySlug), getCategoryBySlug);
 
-router.post("/", authenticateToken, authorizeRole(["ADMIN"]), postCategory);
-router.put("/:id", authenticateToken, authorizeRole(["ADMIN"]), putCategory);
-router.delete("/:id", authenticateToken, authorizeRole(["ADMIN"]), removeCategory);
+router.post(
+  "/",
+  authenticateToken,
+  authorizeRole(["ADMIN"]),
+  validateRequest(validationSchemas.categories.create),
+  postCategory
+);
+router.put(
+  "/:id",
+  authenticateToken,
+  authorizeRole(["ADMIN"]),
+  validateRequest(validationSchemas.categories.update),
+  putCategory
+);
+router.delete(
+  "/:id",
+  authenticateToken,
+  authorizeRole(["ADMIN"]),
+  validateRequest(validationSchemas.categories.remove),
+  removeCategory
+);
 
 export default router;

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -4,7 +4,7 @@ import { authenticateToken, validateRequest, validationSchemas } from "../middle
 
 const router = Router();
 
-router.post("/", validateRequest(validationSchemas.orders.create), createOrder);
+router.post("/", authenticateToken, validateRequest(validationSchemas.orders.create), createOrder);
 router.get("/", authenticateToken, getOrders);
 
 export default router;

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { createOrder, getOrders } from "../controllers/orderController";
+import { authenticateToken, validateRequest, validationSchemas } from "../middlewares";
 
 const router = Router();
 
-router.post("/", createOrder);
-router.get("/", getOrders);
+router.post("/", validateRequest(validationSchemas.orders.create), createOrder);
+router.get("/", authenticateToken, getOrders);
 
 export default router;

--- a/server/src/routes/products.ts
+++ b/server/src/routes/products.ts
@@ -7,16 +7,34 @@ import {
   putProduct,
   removeProduct,
 } from "../controllers/productController";
-import { authenticateToken, authorizeRole } from "../middlewares";
+import { authenticateToken, authorizeRole, validateRequest, validationSchemas } from "../middlewares";
 
 const router = Router();
 
 router.get("/featured", getFeaturedProducts);
-router.get("/", getProducts);
-router.get("/:id", getProductById);
+router.get("/", validateRequest(validationSchemas.products.list), getProducts);
+router.get("/:id", validateRequest(validationSchemas.products.byId), getProductById);
 
-router.post("/", authenticateToken, authorizeRole(["ADMIN"]), postProduct);
-router.put("/:id", authenticateToken, authorizeRole(["ADMIN"]), putProduct);
-router.delete("/:id", authenticateToken, authorizeRole(["ADMIN"]), removeProduct);
+router.post(
+  "/",
+  authenticateToken,
+  authorizeRole(["ADMIN"]),
+  validateRequest(validationSchemas.products.create),
+  postProduct
+);
+router.put(
+  "/:id",
+  authenticateToken,
+  authorizeRole(["ADMIN"]),
+  validateRequest(validationSchemas.products.update),
+  putProduct
+);
+router.delete(
+  "/:id",
+  authenticateToken,
+  authorizeRole(["ADMIN"]),
+  validateRequest(validationSchemas.products.remove),
+  removeProduct
+);
 
 export default router;

--- a/server/src/services/inventoryService.ts
+++ b/server/src/services/inventoryService.ts
@@ -1,0 +1,65 @@
+import type { Prisma } from "@prisma/client";
+
+export async function decrementProductStock(
+  tx: Prisma.TransactionClient,
+  productId: number,
+  quantity: number
+): Promise<boolean> {
+  const result = await tx.product.updateMany({
+    where: {
+      id: productId,
+      stock: { gte: quantity },
+    },
+    data: {
+      stock: { decrement: quantity },
+    },
+  });
+
+  return result.count === 1;
+}
+
+export async function incrementProductStock(
+  tx: Prisma.TransactionClient,
+  productId: number,
+  quantity: number
+) {
+  await tx.product.update({
+    where: { id: productId },
+    data: {
+      stock: { increment: quantity },
+    },
+  });
+}
+
+export async function decrementVariantStock(
+  tx: Prisma.TransactionClient,
+  variantId: number,
+  productId: number,
+  quantity: number
+): Promise<boolean> {
+  const result = await tx.productVariant.updateMany({
+    where: {
+      id: variantId,
+      productId,
+      stock: { gte: quantity },
+    },
+    data: {
+      stock: { decrement: quantity },
+    },
+  });
+
+  return result.count === 1;
+}
+
+export async function incrementVariantStock(
+  tx: Prisma.TransactionClient,
+  variantId: number,
+  quantity: number
+) {
+  await tx.productVariant.update({
+    where: { id: variantId },
+    data: {
+      stock: { increment: quantity },
+    },
+  });
+}

--- a/server/tests/api/route-protections.api.test.ts
+++ b/server/tests/api/route-protections.api.test.ts
@@ -16,6 +16,7 @@ describe('route protections and validation contracts', () => {
     await request(app).get('/api/auth/profile').expect(401);
     await request(app).get('/api/auth/admin-only').expect(401);
     await request(app).get('/api/cart').expect(401);
+    await request(app).get('/api/orders').expect(401);
     await request(app).post('/api/cart/items').send({ productId: 1, quantity: 1 }).expect(401);
     await request(app).patch('/api/cart/items/1').send({ quantity: 2 }).expect(401);
     await request(app).delete('/api/cart/items/1').expect(401);

--- a/server/tests/api/security-validation.api.test.ts
+++ b/server/tests/api/security-validation.api.test.ts
@@ -1,0 +1,103 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/app";
+import { generateToken } from "../../src/config/jwt";
+
+const clientToken = generateToken({
+  id: "1",
+  email: "client@example.com",
+  role: "CLIENT",
+});
+
+const adminToken = generateToken({
+  id: "2",
+  email: "admin@example.com",
+  role: "ADMIN",
+});
+
+describe("security validation contracts", () => {
+  it("rejects invalid auth payloads and unexpected fields", async () => {
+    const app = createApp();
+
+    const invalidLogin = await request(app).post("/api/auth/login").send({
+      email: "not-an-email",
+      password: "123",
+      unexpected: true,
+    });
+
+    expect(invalidLogin.status).toBe(400);
+    expect(invalidLogin.body.success).toBe(false);
+
+    const invalidRegister = await request(app).post("/api/auth/register").send({
+      name: " ",
+      email: " BAD@EXAMPLE.COM ",
+      password: "short",
+      role: "ADMIN",
+    });
+
+    expect(invalidRegister.status).toBe(400);
+    expect(invalidRegister.body.success).toBe(false);
+  });
+
+  it("rejects invalid cart and order payloads before hitting deeper logic", async () => {
+    const app = createApp();
+
+    const invalidCart = await request(app)
+      .post("/api/cart/items")
+      .set("Authorization", `Bearer ${clientToken}`)
+      .send({ productId: 0, quantity: -1, unexpected: true });
+
+    expect(invalidCart.status).toBe(400);
+    expect(invalidCart.body.success).toBe(false);
+
+    const invalidOrder = await request(app)
+      .post("/api/orders")
+      .send({
+        name: "A",
+        email: " BAD@EXAMPLE.COM ",
+        address: "x",
+        city: "",
+        country: "AR",
+        postalCode: "12",
+        phone: "123",
+        paymentMethod: "bitcoin",
+        items: [{ productId: 1, quantity: 0, price: -1 }],
+      });
+
+    expect(invalidOrder.status).toBe(400);
+    expect(invalidOrder.body.success).toBe(false);
+  });
+
+  it("rejects invalid query or body data on product, category, and admin critical endpoints", async () => {
+    const app = createApp();
+
+    await request(app).get("/api/products?minPrice=100&maxPrice=10").expect(400);
+
+    await request(app)
+      .post("/api/products")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        name: "A",
+        price: -10,
+        imageUrl: "not-a-url",
+        stock: -1,
+        categoryId: 0,
+      })
+      .expect(400);
+
+    await request(app)
+      .post("/api/categories")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        name: "Moda",
+        slug: "Slug Invalido",
+      })
+      .expect(400);
+
+    await request(app)
+      .patch("/api/admin/orders/abc/status")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ status: "UNKNOWN" })
+      .expect(400);
+  });
+});

--- a/server/tests/api/security-validation.api.test.ts
+++ b/server/tests/api/security-validation.api.test.ts
@@ -52,6 +52,7 @@ describe("security validation contracts", () => {
 
     const invalidOrder = await request(app)
       .post("/api/orders")
+      .set("Authorization", `Bearer ${clientToken}`)
       .send({
         name: "A",
         email: " BAD@EXAMPLE.COM ",

--- a/server/tests/unit/authControllerLogin.unit.test.ts
+++ b/server/tests/unit/authControllerLogin.unit.test.ts
@@ -1,0 +1,88 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findUserByEmail, validatePassword } = vi.hoisted(() => ({
+  findUserByEmail: vi.fn(),
+  validatePassword: vi.fn(),
+}));
+
+vi.mock("../../src/services/userService", () => ({
+  findUserByEmail,
+  validatePassword,
+}));
+
+vi.mock("../../src/config/jwt", () => ({
+  generateToken: vi.fn(() => "token-falso"),
+}));
+
+import { login } from "../../src/controllers/authControllerLogin";
+
+function createResponseMock() {
+  const response = {
+    status: vi.fn(),
+    json: vi.fn(),
+  } as unknown as Response;
+
+  vi.mocked(response.status).mockReturnValue(response);
+  vi.mocked(response.json).mockReturnValue(response);
+
+  return response;
+}
+
+describe("authControllerLogin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the same failure response for nonexistent email and wrong password", async () => {
+    const missingUserReq = {
+      body: { email: "ghost@example.com", password: "Password123!" },
+    } as Request;
+    const missingUserRes = createResponseMock();
+
+    findUserByEmail.mockResolvedValueOnce(null);
+    validatePassword.mockResolvedValueOnce(false);
+
+    await login(missingUserReq, missingUserRes);
+
+    expect(validatePassword).toHaveBeenCalledTimes(1);
+    expect(missingUserRes.status).toHaveBeenCalledWith(401);
+
+    const missingUserBody = vi.mocked(missingUserRes.json).mock.calls[0]?.[0];
+
+    const wrongPasswordReq = {
+      body: { email: "user@example.com", password: "Password123!" },
+    } as Request;
+    const wrongPasswordRes = createResponseMock();
+
+    findUserByEmail.mockResolvedValueOnce({
+      id: 10,
+      name: "User",
+      email: "user@example.com",
+      password: "$2b$10$stored-hash-example.................",
+      role: "CLIENT",
+    });
+    validatePassword.mockResolvedValueOnce(false);
+
+    await login(wrongPasswordReq, wrongPasswordRes);
+
+    expect(validatePassword).toHaveBeenCalledTimes(2);
+    expect(wrongPasswordRes.status).toHaveBeenCalledWith(401);
+    expect(vi.mocked(wrongPasswordRes.json).mock.calls[0]?.[0]).toEqual(missingUserBody);
+  });
+
+  it("always invokes password verification even when the user does not exist", async () => {
+    const req = {
+      body: { email: "ghost@example.com", password: "Password123!" },
+    } as Request;
+    const res = createResponseMock();
+
+    findUserByEmail.mockResolvedValueOnce(null);
+    validatePassword.mockResolvedValueOnce(false);
+
+    await login(req, res);
+
+    expect(validatePassword).toHaveBeenCalledWith("Password123!", expect.any(String));
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/server/tests/unit/inventoryService.unit.test.ts
+++ b/server/tests/unit/inventoryService.unit.test.ts
@@ -1,0 +1,32 @@
+import type { Prisma } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import { decrementProductStock } from "../../src/services/inventoryService";
+
+describe("inventoryService", () => {
+  it("prevents overselling under concurrent conditional decrements", async () => {
+    let stock = 5;
+
+    const tx = {
+      product: {
+        updateMany: vi.fn(async ({ where }: { where: { stock: { gte: number } } }) => {
+          const requested = where.stock.gte;
+
+          if (stock >= requested) {
+            stock -= requested;
+            return { count: 1 };
+          }
+
+          return { count: 0 };
+        }),
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    const [firstAttempt, secondAttempt] = await Promise.all([
+      decrementProductStock(tx, 1, 4),
+      decrementProductStock(tx, 1, 4),
+    ]);
+
+    expect([firstAttempt, secondAttempt].sort()).toEqual([false, true]);
+    expect(stock).toBe(1);
+  });
+});

--- a/server/tests/unit/orderController.security.unit.test.ts
+++ b/server/tests/unit/orderController.security.unit.test.ts
@@ -1,0 +1,159 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+    order: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../src/config/prisma", () => ({
+  default: prismaMock,
+}));
+
+vi.mock("bcrypt", () => ({
+  default: {
+    hash: vi.fn(async () => "hashed-checkout-password"),
+  },
+}));
+
+import { createOrder } from "../../src/controllers/orderController";
+
+function createResponseMock() {
+  const response = {
+    status: vi.fn(),
+    json: vi.fn(),
+  } as unknown as Response;
+
+  vi.mocked(response.status).mockReturnValue(response);
+  vi.mocked(response.json).mockReturnValue(response);
+
+  return response;
+}
+
+describe("orderController security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recomputes authoritative prices from the database during order creation", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 55 });
+
+    const tx = {
+      cart: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+      cartItem: {
+        deleteMany: vi.fn(),
+      },
+      product: {
+        findMany: vi.fn().mockResolvedValue([{ id: 7, price: 99 }]),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        create: vi.fn().mockImplementation(async ({ data }) => ({
+          id: 501,
+          ...data,
+          items: data.items.create,
+          user: { id: 55, name: data.name, email: data.email },
+        })),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    const req = {
+      headers: {},
+      body: {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        address: "Main Street 123",
+        city: "Cordoba",
+        country: "AR",
+        postalCode: "5000",
+        phone: "3511234567",
+        paymentMethod: "tarjeta",
+        items: [{ productId: 7, quantity: 2, price: 1 }],
+      },
+    } as Request;
+    const res = createResponseMock();
+
+    await createOrder(req, res);
+
+    expect(tx.product.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 7,
+          stock: { gte: 2 },
+        }),
+      })
+    );
+    expect(tx.order.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          total: 198,
+          items: {
+            create: [{ productId: 7, quantity: 2, price: 99 }],
+          },
+        }),
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("rejects the order when authoritative stock cannot be reserved", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 55 });
+
+    const tx = {
+      cart: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+      cartItem: {
+        deleteMany: vi.fn(),
+      },
+      product: {
+        findMany: vi.fn().mockResolvedValue([{ id: 7, price: 99 }]),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      order: {
+        create: vi.fn(),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    const req = {
+      headers: {},
+      body: {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        address: "Main Street 123",
+        city: "Cordoba",
+        country: "AR",
+        postalCode: "5000",
+        phone: "3511234567",
+        paymentMethod: "tarjeta",
+        items: [{ productId: 7, quantity: 2, price: 1 }],
+      },
+    } as Request;
+    const res = createResponseMock();
+
+    await createOrder(req, res);
+
+    expect(tx.order.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(vi.mocked(res.json).mock.calls[0]?.[0]).toEqual({
+      success: false,
+      message: "Stock insuficiente para completar la orden",
+    });
+  });
+});

--- a/server/tests/unit/orderController.security.unit.test.ts
+++ b/server/tests/unit/orderController.security.unit.test.ts
@@ -71,6 +71,7 @@ describe("orderController security", () => {
     prismaMock.$transaction.mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
 
     const req = {
+      userId: 55,
       headers: {},
       body: {
         name: "Ada Lovelace",
@@ -109,6 +110,68 @@ describe("orderController security", () => {
     expect(res.status).toHaveBeenCalledWith(201);
   });
 
+  it("decrements stock from product variants when variantId is provided", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ id: 55 });
+
+    const tx = {
+      cart: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+      cartItem: {
+        deleteMany: vi.fn(),
+      },
+      product: {
+        findMany: vi.fn().mockResolvedValue([{ id: 7, price: 99 }]),
+        updateMany: vi.fn(),
+      },
+      productVariant: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      order: {
+        create: vi.fn().mockImplementation(async ({ data }) => ({
+          id: 501,
+          ...data,
+          items: data.items.create,
+          user: { id: 55, name: data.name, email: data.email },
+        })),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    const req = {
+      userId: 55,
+      headers: {},
+      body: {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        address: "Main Street 123",
+        city: "Cordoba",
+        country: "AR",
+        postalCode: "5000",
+        phone: "3511234567",
+        paymentMethod: "tarjeta",
+        items: [{ productId: 7, variantId: 99, quantity: 2, price: 1 }],
+      },
+    } as unknown as Request;
+    const res = createResponseMock();
+
+    await createOrder(req, res);
+
+    expect(tx.productVariant.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 99,
+          productId: 7,
+          stock: { gte: 2 },
+        }),
+      })
+    );
+    expect(tx.product.updateMany).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
   it("rejects the order when authoritative stock cannot be reserved", async () => {
     prismaMock.user.findUnique.mockResolvedValue({ id: 55 });
 
@@ -132,6 +195,7 @@ describe("orderController security", () => {
     prismaMock.$transaction.mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
 
     const req = {
+      userId: 55,
       headers: {},
       body: {
         name: "Ada Lovelace",


### PR DESCRIPTION
## Resumen
- Corrige riesgos de overselling en carrito e inventario con reservas atómicas de stock y validación de disponibilidad en checkout.
- Endurece la validación backend con esquemas centralizados, sanitización de entradas críticas y rechazo de payloads inválidos o con campos inesperados.
- Mitiga user enumeration en login, refuerza el tipado de auth/backend y protege el acceso a órdenes del usuario autenticado.

## Qué se hizo
- Se agregó `server/src/services/inventoryService.ts` para encapsular decrementos y restauraciones atómicas de stock usando operaciones condicionales.
- Se refactorizó `server/src/routes/cart.ts` para evitar el patrón inseguro read-then-update y prevenir overselling bajo concurrencia.
- Se reforzó `server/src/controllers/orderController.ts` para recalcular precios de forma autoritativa desde la base de datos, revalidar stock en la creación de órdenes y listar únicamente las órdenes del usuario autenticado.
- Se protegió `GET /api/orders` en `server/src/routes/orders.ts` para que requiera autenticación.
- Se centralizó la validación con Zod en `server/src/middlewares/validation.ts`, cubriendo `body`, `params` y `query` para auth, cart, orders, products, categories y admin.
- Se endurecieron las validaciones de rutas críticas en `server/src/routes/products.ts`, `server/src/routes/categories.ts`, `server/src/routes/admin.ts` y el flujo de registro.
- Se mitigó el timing leak del login en `server/src/controllers/authControllerLogin.ts` haciendo compare de password también para usuarios inexistentes.
- Se reforzó el rate limiting por defecto de auth en `server/src/routes/auth.ts` y `server/src/middlewares/rateLimiter.ts`.
- Se eliminaron usos remanentes de `any` en `server/src` dentro de paths críticos de backend.

## Tests y validación
- Se agregaron tests unitarios para login seguro, inventario atómico y procesamiento autoritativo de órdenes.
- Se agregaron tests API para validación de payloads críticos, rechazo de campos inesperados y protección de `/api/orders`.
- Validación ejecutada localmente en `server/`:
  - `npm test`
  - `npm run lint`
  - verificación sin matches de `any` en `server/src`

## Commits incluidos
- `fix: centralize backend request validation`
- `fix: prevent overselling in cart reservations`
- `fix: secure authoritative order processing`
- `fix: harden login timing and auth typing`