### PR TITLE
docs: sync QA block 5 documentation with develop

### DIFF
--- a/INTEGRACION-SPRINT3.md
+++ b/INTEGRACION-SPRINT3.md
@@ -1,4 +1,17 @@
-# Integración Sprint 3 — Detalle de producto y carrito
+# Integracion Sprint 3 - Detalle de producto y carrito
+
+> Nota historica: este archivo se conserva como referencia del trabajo de integracion del Sprint 3.
+>
+> No debe usarse como fuente canonica del estado actual del sistema.
+>
+> Para contratos vigentes, reglas observadas, brechas activas y trazabilidad de QA revisa:
+>
+> - `docs/README.md`
+> - `docs/business-rules-cart-order-payment.md`
+> - `docs/api-contracts-and-errors.md`
+> - `docs/permissions-and-env.md`
+>
+> Este archivo puede contener referencias historicas hoy desactualizadas sobre ramas, rutas, contratos o destino de PRs.
 
 ## Rama de trabajo
 - `feat/integracion-sprint3-carrito`

--- a/README.md
+++ b/README.md
@@ -1,378 +1,177 @@
 # Ecommerce Vibe Pulse
 
-Aplicación web de e-commerce de ropa juvenil. Este repositorio contiene el Sprint 1: **Autenticación y Registro de Usuarios**.
+Aplicacion web de e-commerce con frontend en React/Vite y backend en Express/Prisma. El estado actual de `develop` ya incluye autenticacion, catalogo, carrito, checkout, ordenes y modulo administrativo.
 
-## Tecnologías
+## Estado actual
 
-- **Frontend:** React 18 + Vite + TypeScript + Tailwind CSS
-- **Backend:** Node.js + Express + TypeScript
-- **Base de datos:** PostgreSQL + Prisma ORM
-- **Seguridad:** bcrypt para contraseñas
+- Este repositorio ya no corresponde solo a Sprint 1.
+- Alcance observable hoy:
+  - autenticacion y registro
+  - catalogo y categorias
+  - carrito persistente para usuario autenticado
+  - checkout y creacion de orden
+  - panel administrativo
+  - pruebas API, component y E2E base
 
----
+## Documentacion tecnica del Bloque 5
 
-## Requisitos previos
+Referencia canonica actual:
 
-Antes de empezar, asegúrate de tener instalado:
+- `docs/README.md`
+- `docs/data-model.md`
+- `docs/auth-session.md`
+- `docs/business-rules-cart-order-payment.md`
+- `docs/traceability-matrix.md`
+- `docs/api-contracts-and-errors.md`
+- `docs/permissions-and-env.md`
+- `docs/architecture-diagrams.md`
 
-- [Node.js](https://nodejs.org/) v18 o superior
-- [PostgreSQL](https://www.postgresql.org/) corriendo en tu máquina (puerto 5432 por defecto)
-- npm (viene con Node.js)
+Contexto local usado para QA:
 
----
+- `docs/Informe_Consolidado_QA_VibePulse.docx.pdf`
 
-## Configuración de la Base de Datos
+Referencia historica de integracion:
 
-1. Abre tu cliente de PostgreSQL (pgAdmin, DBeaver, o la terminal).
-2. Crea una base de datos llamada `ecommerce`:
-   ```sql
-   CREATE DATABASE ecommerce;
-   ```
-3. Anota tu usuario y contraseña de PostgreSQL, los necesitarás en el siguiente paso.
+- `INTEGRACION-SPRINT3.md`
 
----
+## Stack
 
-## Backend
+- Frontend: React 18 + Vite + TypeScript + Tailwind CSS
+- Backend: Node.js + Express + TypeScript
+- Base de datos: PostgreSQL + Prisma ORM
+- Seguridad: JWT + bcrypt
+- Testing: Vitest, Supertest, Cypress Component, Playwright
 
-### 1. Instalar dependencias
+## Configuracion rapida
+
+### Backend
 
 ```bash
 cd server
 npm install
-```
-
-### 2. Configurar variables de entorno
-
-> **⚠️ IMPORTANTE DE SEGURIDAD:** A partir de Sprint 1, `JWT_SECRET` es **OBLIGATORIO** y debe estar en el archivo `.env`. El servidor no arrancará sin él.
-
-Copia el archivo `server/.env.example` a `server/.env` y ajusta los valores según tu configuración:
-
-```bash
-cp server/.env.example server/.env
-```
-
-Luego edita `server/.env` con tus valores:
-
-```env
-# Base de datos
-DATABASE_URL="postgresql://postgres:TU_CONTRASEÑA@localhost:5432/ecommerce"
-
-# Servidor
-PORT=4000
-
-# JWT - CRÍTICO: genera una clave segura
-# Nunca uses la clave por defecto en producción
-JWT_SECRET="tu-clave-secreta-larga-y-segura-aqui"
-Copia el resultado y pégalo como valor de `JWT_SECRET` en tu `.env`.
-
-### 3. Crear las tablas en la base de datos
-
-```bash
+cp .env.example .env
 npx prisma db push
-```
-
-Esto lee el archivo `server/prisma/schema.prisma` y crea la tabla `User` en tu base de datos automáticamente.
-
-### 4. Iniciar el servidor (Desarrollo)
-
-```bash
+npx prisma db seed
 npm run dev
 ```
 
-El servidor arranca en `http://localhost:4000`.
+Puerto observado por defecto:
 
-### 5. Compilar y ejecutar para Producción
+- `http://localhost:3000`
 
-Para compilar el proyecto y ejecutar la versión optimizada:
+Health check observado:
 
-```bash
-npm run build
-npm run start
-```
-
-Para verificar que esté corriendo, abre en el navegador:
-```
-http://localhost:4000/api/health
-```
-
-Deberías ver:
 ```json
-{"status":"ok","message":"Authentication API is running"}
+{"status":"ok","message":"API is running"}
 ```
 
-**Solución de problemas:**
-- ❌ Error: `JWT_SECRET environment variable is not set` → Verifica que `JWT_SECRET` esté en `.env` con un valor válido
-- ❌ Error de conexión a BD → Revisa `DATABASE_URL` y que PostgreSQL esté corriendo
-- ❌ Token inválido o expirado → Inicia sesión nuevamente para obtener un token fresco
+Variables clave observadas:
 
----
+- `DATABASE_URL`
+- `PORT`
+- `JWT_SECRET`
+- `JWT_EXPIRY`
+- `CLIENT_ORIGIN`
+- `RATE_LIMIT_MAX_REQUESTS`
+- `RATE_LIMIT_WINDOW_MS`
+- `AUTH_RATE_LIMIT_MAX_REQUESTS`
+- `AUTH_RATE_LIMIT_WINDOW_MS`
+- `TRUST_PROXY_HOPS`
 
-## Frontend
-
-Abre una **nueva terminal** (sin cerrar la del backend).
-
-### 1. Instalar dependencias
+### Frontend
 
 ```bash
 cd client
 npm install
-```
-
-### 2. Iniciar la aplicación (Desarrollo)
-
-```bash
 npm run dev
 ```
 
-La aplicación abre en `http://localhost:5173`.
-*(Nota: Si el puerto 5173 está ocupado, Vite abrirá automáticamente en el `5174` u otro superior. El servidor Backend está configurado con CORS dinámico (`origin: true`) para permitir peticiones desde cualquier puerto local originado por Vite sin bloquearte).*
+Puerto de desarrollo esperado:
 
-### 3. Compilar y previsualizar para Producción
+- `http://localhost:5173`
 
-Para compilar el proyecto optimizado y previsualizar el build:
+Backend por defecto si no se define `VITE_API_URL`:
+
+- `http://localhost:3000`
+
+## Flujos principales observables
+
+- Registro y login con JWT.
+- Guards de frontend para usuario autenticado y admin.
+- Carrito protegido con reserva atomica de stock.
+- Checkout con metodos `tarjeta` y `paypal` simulados.
+- Creacion de orden con recalculo autoritativo de precios.
+- Backoffice admin para metricas, usuarios, pedidos, productos y categorias.
+
+## Endpoints principales
+
+### Publicos observados
+
+- `GET /api/health`
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `GET /api/products`
+- `GET /api/products/featured`
+- `GET /api/products/:id`
+- `GET /api/categories`
+- `GET /api/categories/:slug`
+- `POST /api/orders`
+
+### Protegidos observados
+
+- `GET /api/auth/me`
+- `GET /api/auth/profile`
+- `GET /api/auth/admin-only`
+- `GET /api/cart`
+- `POST /api/cart/items`
+- `PATCH /api/cart/items/:id`
+- `DELETE /api/cart/items/:id`
+- `GET /api/orders`
+- `GET /api/admin/dashboard/metrics`
+- `GET /api/admin/users`
+- `GET /api/admin/orders`
+- `PATCH /api/admin/orders/:id/status`
+- mutaciones admin de productos y categorias
+
+## Tension abierta importante
+
+El criterio del equipo expresado en el review de la PR `#17` pide tratar ordenes como flujo `100%` autenticado y alineado con la solucion segura de la PR `#14`. El `develop` actual no cierra del todo esa expectativa:
+
+- frontend: `/checkout` esta protegido y `createOrderRequest` usa request autenticada
+- backend: `GET /api/orders` si requiere token
+- backend: `POST /api/orders` sigue sin `authenticateToken`
+
+La documentacion del Bloque 5 toma `develop` como verdad principal y deja esa diferencia como brecha activa, no como contrato falso.
+
+## Seguridad relevante hoy
+
+- Registro duplicado responde `400` con mensaje generico.
+- Login usa comparacion dummy para reducir timing leak.
+- Inventario de carrito y orden usa operaciones atomicas sobre producto o variante.
+- El backend recalcula el total de orden con precio de base de datos.
+
+## Cuenta admin por seed
+
+El proyecto incluye seed para cuenta administrativa. Revisa `server/prisma/seed.ts` y `server/.env.example` antes de usar credenciales en entornos compartidos.
+
+## Testing rapido
+
+Backend:
 
 ```bash
-npm run build
-npm run preview
+cd server
+npm test
 ```
 
-La aplicación de producción (preview) se abrirá generalmente en `http://localhost:4173`.
-
-### 4. Ejecutar pruebas del frontend
+Frontend:
 
 ```bash
+cd client
 npm run test
 npm run test:component
 npm run test:e2e
 ```
 
-#### Estrategia de testing frontend
-
-- **Vitest**: lógica unitaria y render simple.
-- **Cypress Component Testing**: componentes con `React Router`, `CheckoutProvider`, `CartProvider` y páginas admin con `useOutletContext`.
-- **Playwright**: flujos end-to-end.
-
-#### Patrones de Component Testing
-
-- Los specs viven en `client/cypress/component`.
-- El helper compartido está en `client/cypress/support/mount.tsx`.
-- Usa `cy.mount()` con opciones como:
-  - `routerProps`
-  - `withCheckoutProvider`
-  - `withCartProvider`
-  - `outletContext`
-  - `auth`
-- Las fixtures base viven en `client/cypress/fixtures`.
-
----
-
-## Uso
-
-Una vez que tanto el backend como el frontend están corriendo:
-
-- Entra a `http://localhost:5173` — te redirige automáticamente a `/login`.
-- **Registro:** Ve a `/register`, completa el formulario y crea tu cuenta.
-  - Todos los usuarios registrados se crean con rol `CLIENT` por defecto.
-  - Para crear cuentas `ADMIN`, usa la herramienta de migración o seed de Prisma (ver sección de Administración).
-- **Login:** Ingresa con tu correo y contraseña.
-  - Si el rol es `CLIENT` → redirige a `/home`.
-  - Si el rol es `ADMIN` → redirige a `/admin`.
-
-### Crear una cuenta de administrador (Paso a paso)
-
-Los usuarios registrados desde la web (`/register`) se crean siempre con el rol `CLIENT`. Por seguridad, las cuentas con privilegios de **ADMIN** se gestionan exclusivamente desde el servidor.
-
-> **Regla de Oro:** Las cuentas ADMIN deben crearse mediante una seed de Prisma o un proceso administrativo controlado.
-
-#### Pasos para generar el administrador inicial:
-
-1.  **Entra a la carpeta del servidor:**
-    ```bash
-    cd server
-    ```
-
-2.  **Ejecuta el comando de Seed:**
-    Este comando activa el script automatizado que inserta el administrador en la base de datos.
-    ```bash
-    npx prisma db seed
-    ```
-
-3.  **Verificar el resultado:**
-    Deberías ver un mensaje en consola confirmando: `Admin user creado/actualizado: admin@vibepulse.com`.
-
-#### Credenciales por defecto (Generadas por el Seed):
-Una vez ejecutado el comando, usa estos datos para entrar al panel de administración:
-- **Email:** `admin@vibepulse.com`
-- **Contraseña:** `AdminPassword123!`
-
-*Nota: Para cambiar estas credenciales, edita el archivo `server/prisma/seed.ts` y vuelve a ejecutar el comando `npx prisma db seed`.*
-
----
-
-#### ¿Por qué este método? (Mejores prácticas)
-- **Cero registros públicos:** Evitamos que cualquier usuario se asigne el rol de ADMIN desde el navegador.
-- **Contraseñas Seguras:** El script hashea la contraseña automáticamente usando `bcrypt` antes de guardarla.
-- **Sin Lógica "Mágica":** No dependemos de que el sistema "detecte" emails que terminen en `@admin.com`, evitando vulnerabilidades.
-
----
-
-## Rate Limiting por ambiente
-
-- `NODE_ENV=test`: rate limiter desactivado (bypass) para pruebas controladas.
-- `NODE_ENV=development`: límites más permisivos (mínimo 1000 requests por ventana) y whitelist local activa.
-- `NODE_ENV=production`: límites restrictivos por defecto (`100/60s` general y `5/15m` para auth).
-
-### Whitelist local para pruebas
-
-En `development` se hace bypass para IPs locales exactas: `127.0.0.1`, `::1`, `::ffff:127.0.0.1`.
-Esto evita bloqueos 429 durante pruebas de carga/controladas en entorno local.
-
-## Endpoints de la API
-
-### Públicos (sin autenticación)
-
-| Método | Ruta | Descripción |
-|--------|------|-------------|
-| `GET`  | `/api/health` | Verifica que el servidor esté activo |
-| `POST` | `/api/auth/register` | Registra un nuevo usuario (rol: CLIENT) |
-| `POST` | `/api/auth/login` | Inicia sesión y devuelve JWT token |
-
-### Protegidos (requieren JWT Bearer token)
-
-| Método | Ruta | Autorización | Descripción |
-|--------|------|-------------|-------------|
-| `GET`  | `/api/auth/me` | Cualquier usuario autenticado | Obtiene datos del usuario autenticado |
-| `GET`  | `/api/auth/profile` | Cualquier usuario autenticado | Obtiene perfil detallado del usuario |
-| `GET`  | `/api/auth/admin-only` | Solo ADMIN | Verifica acceso de administrador |
-
-### Ejemplos de cuerpo (JSON)
-
-**Registro:**
-```json
-{
-  "name": "Alex Rivera",
-  "email": "alex@ejemplo.com",
-  "password": "Contraseña123!"
-}
-```
-
-**Login:**
-```json
-{
-  "email": "alex@ejemplo.com",
-  "password": "Contraseña123!"
-}
-```
-
-### Usando endpoints protegidos
-
-Para acceder a endpoints protegidos, incluye el JWT en el header `Authorization`:
-
-```bash
-curl -X GET http://localhost:4000/api/auth/me \
-  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-```
-
-**Respuesta esperada:**
-```json
-{
-  "message": "Datos del usuario autenticado",
-  "user": {
-    "id": "1",
-    "email": "alex@ejemplo.com",
-    "role": "CLIENT"
-  }
-}
-```
-
-### Códigos de error comunes
-
-| Código | Mensaje | Solución |
-|--------|---------|----------|
-| 400 | Datos inválidos | Verifica que todos los campos requeridos estén presentes y válidos |
-| 409 | Ya existe una cuenta con ese correo | Intenta con otro email o inicia sesión |
-| 401 | Correo o contraseña incorrectos | Verifica tus credenciales |
-| 401 | Token no proporcionado | Incluye el header `Authorization: Bearer <token>` |
-| 401 | Token inválido o expirado | Inicia sesión nuevamente |
-| 403 | Acceso denegado | Tu rol no tiene permisos para este recurso |
-| 429 | Demasiadas solicitudes | Espera antes de reintentar (rate limit alcanzado) |
-
----
-
-## Seguridad y Buenas Prácticas
-
-### Cambios de seguridad en Sprint 1
-
-✅ **JWT_SECRET obligatorio**
-- El servidor ahora falla si no existe una variable de entorno `JWT_SECRET` válida
-- Esto previene inicios accidentales con claves inseguras
-
-✅ **Sin escalamiento de privilegios por email**
-- Eliminada la asignación automática de rol ADMIN basada en email
-- Los nuevos usuarios siempre se crean con rol `CLIENT`
-- Los admins solo se pueden crear mediante procesos administrativos verificados
-
-✅ **Validaciones consistentes**
-- Contraseña mínima de **8 caracteres** en frontend y backend
-- Validaciones duplicadas previenen inconsistencias
-
-✅ **Endpoints protegidos**
-- Nuevos endpoints (`/me`, `/profile`, `/admin-only`) demuestran protección real
-- Middleware `authenticateToken` y `authorizeRole` implementados
-
-✅ **Hashing de contraseñas**
-- bcrypt con 10 rounds implementado en backend
-- Las contraseñas nunca se almacenan en texto plano
-
-✅ **Rate limiting**
-- 5 intentos por 15 minutos en endpoints de auth
-- 100 solicitudes por minuto globalmente
-
-### Requisitos de contraseña
-
-- **Mínimo 8 caracteres**
-- Sin restricciones específicas de complejidad (educativo)
-- Considera agregar: mayúsculas, minúsculas, números y símbolos en producción
-
-### Para llevar a producción
-
-- [ ] Cambiar `CLIENT_ORIGIN` a dominio real
-- [ ] Usar HTTPS en lugar de HTTP
-- [ ] Ampliar JWT_EXPIRY según necesidad (default: 7 días)
-- [ ] Implementar refresh tokens
-- [ ] Agregar 2FA (Two-Factor Authentication)
-- [ ] Usar secrets management (AWS Secrets, Vault, etc.) en lugar de `.env`
-- [ ] Agregar logging de intentos fallidos
-- [ ] Implementar CAPTCHA en login/register si es público
-
-```
-ecommerce-vibe-pulse/
-├── client/            # Frontend
-│   ├── public/        # Recursos estáticos (ej. logo.png como favicon)
-│   ├── src/
-│   │   ├── assets/    # Imágenes y recursos internos
-│   │   ├── pages/     # Login, Register, Home, Admin
-│   │   ├── routes/    # Rutas protegidas
-│   │   ├── services/  # Llamadas a la API
-│   │   └── utils/     # Manejo de sesión (localStorage)
-│   ├── tailwind.config.js # Configuración de Tailwind CSS
-│   └── vite.config.ts   # Configuración de Vite (incluye setup de PostCSS para Tailwind)
-├── server/            # Backend
-│   ├── prisma/        # Schema de la base de datos
-│   └── src/
-│       ├── config/    # Conexión a Prisma
-│       ├── controllers/
-│       ├── routes/
-│       └── services/  # Lógica con bcrypt y Prisma
-└── README.md
-```
-
----
-
-## Contribuciones
-
-Si encuentras un problema o tienes sugerencias, abre un issue o haz un pull request.
-
 ## Licencia
 
-Este proyecto es educativo para el Sprint 1 del bootcamp.
+Proyecto con fin educativo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# Bloque 5 QA
+
+## Alcance
+
+Esta carpeta rehace la documentacion de la issue `#12` sobre `origin/develop`.
+
+Cobertura del bloque:
+
+- `QA-016`: modelo de datos
+- `QA-017`: sesion y JWT
+- `QA-018`: reglas de carrito, checkout, orden y pago
+- `QA-019`: trazabilidad requisito -> codigo -> prueba
+- `QA-020`: contratos API, errores, permisos, entorno y diagramas minimos
+
+## Fuentes obligatorias usadas
+
+- issue `#12`
+- review principal de la PR `#17`
+- PRs `#14`, `#16` y `#18`
+- `origin/develop`
+- `docs/Informe_Consolidado_QA_VibePulse.docx.pdf` como contexto local de trabajo
+
+## Regla de lectura
+
+Cada documento separa cuatro capas:
+
+1. estado actual observado en `develop`
+2. evidencia concreta en archivos, tests o PRs aceptadas
+3. decisiones pendientes o brechas activas
+4. propuesta de estandarizacion futura
+
+## Criterio editorial aplicado
+
+- `develop` es la fuente principal del estado actual.
+- Las PRs `#14`, `#16` y `#18` se usan como contexto de intencion y validacion del equipo.
+- Si el review de la PR `#17` afirma una solucion que `develop` no refleja por completo, esa diferencia se documenta como brecha abierta.
+- No se documentan bugs viejos ya corregidos como si fueran reglas oficiales.
+- Tampoco se vende como implementado algo que `develop` todavia no cumple.
+
+## Mapa de documentos
+
+- `docs/data-model.md`: `QA-016`
+- `docs/auth-session.md`: `QA-017`
+- `docs/business-rules-cart-order-payment.md`: `QA-018`
+- `docs/traceability-matrix.md`: `QA-019`
+- `docs/api-contracts-and-errors.md`: `QA-020`
+- `docs/permissions-and-env.md`: permisos, variables y despliegue local
+- `docs/architecture-diagrams.md`: diagramas de componentes, compra y responsabilidades
+
+## Tension principal del bloque
+
+El review de la PR `#17` pide documentar el flujo de orden como `100%` autenticado y alineado con la solucion segura de la PR `#14`. Sin embargo, el `develop` actual mantiene una tension real:
+
+- el frontend trata checkout y creacion de orden como flujo autenticado
+- `GET /api/orders` si exige token
+- `POST /api/orders` sigue expuesto sin `authenticateToken`
+- `server/src/controllers/orderController.ts` todavia acepta `userId` del cliente y puede resolver o crear usuario por email
+
+Esa tension no se oculta en esta carpeta; se marca como brecha activa hasta que el codigo y los tests converjan.
+
+## Uso recomendado
+
+- Para estado funcional y alcance general: `README.md`
+- Para contratos de backend: `docs/api-contracts-and-errors.md`
+- Para seguridad de sesion y rutas: `docs/auth-session.md`
+- Para reglas de compra e inventario: `docs/business-rules-cart-order-payment.md`
+- Para evidencia cruzada de QA: `docs/traceability-matrix.md`

--- a/docs/api-contracts-and-errors.md
+++ b/docs/api-contracts-and-errors.md
@@ -1,0 +1,224 @@
+# Contratos API y errores
+
+## 1. Estado actual observado en develop
+
+`develop` expone un inventario de rutas estable y util para QA, pero no un contrato unico de errores. El sistema mezcla respuestas centralizadas via `errorHandler` con respuestas manuales de controladores.
+
+## 2. Evidencia concreta
+
+- Inventario de endpoints: `server/tests/api/route-manifest.contract.test.ts`
+- Protecciones: `server/tests/api/route-protections.api.test.ts`
+- Auth: `server/src/controllers/authControllerLogin.ts`, `server/src/controllers/authControllerRegister.ts`
+- Ordenes: `server/src/controllers/orderController.ts`, `server/tests/api/orders.api.test.ts`
+- Validacion centralizada: `server/src/middlewares/validation.ts`
+- Error handler: `server/src/middlewares/errorHandler.ts`
+- Contexto de intencion: review de PR `#17`, PRs `#14`, `#16` y `#18`
+
+## 3. Contratos actuales observados
+
+### Endpoints publicos observados
+
+- `GET /api/health`
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `GET /api/products/`
+- `GET /api/products/featured`
+- `GET /api/products/:id`
+- `GET /api/categories/`
+- `GET /api/categories/:slug`
+- `POST /api/orders/`
+
+### Endpoints protegidos observados
+
+- `GET /api/auth/me`
+- `GET /api/auth/profile`
+- `GET /api/auth/admin-only`
+- `GET /api/cart/`
+- `POST /api/cart/items`
+- `PATCH /api/cart/items/:id`
+- `DELETE /api/cart/items/:id`
+- `GET /api/orders/`
+- `GET /api/admin/dashboard/metrics`
+- `GET /api/admin/users`
+- `GET /api/admin/orders`
+- `PATCH /api/admin/orders/:id/status`
+- `POST /api/products/`
+- `PUT /api/products/:id`
+- `DELETE /api/products/:id`
+- `POST /api/categories/`
+- `PUT /api/categories/:id`
+- `DELETE /api/categories/:id`
+
+### Contratos concretos relevantes
+
+#### `POST /api/auth/register`
+
+Request observado:
+
+```json
+{
+  "name": "Usuario",
+  "email": "user@example.com",
+  "password": "Password123"
+}
+```
+
+Respuesta exitosa observada:
+
+```json
+{
+  "message": "Registro exitoso",
+  "token": "<jwt>",
+  "user": {
+    "id": 1,
+    "name": "Usuario",
+    "email": "user@example.com",
+    "role": "CLIENT"
+  }
+}
+```
+
+Contrato de seguridad vigente:
+
+- ante duplicado de email, responde `400` con mensaje generico
+- no usa `409` ni confirma si el correo existe
+
+#### `POST /api/auth/login`
+
+Request observado:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "Password123"
+}
+```
+
+Respuesta exitosa observada:
+
+```json
+{
+  "message": "Inicio de sesion exitoso",
+  "token": "<jwt>",
+  "user": {
+    "id": 1,
+    "name": "Usuario",
+    "email": "user@example.com",
+    "role": "CLIENT"
+  }
+}
+```
+
+#### `GET /api/cart`
+
+Respuesta de alto nivel observada:
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "userId": 1,
+    "total": 0,
+    "items": []
+  }
+}
+```
+
+#### `POST /api/orders`
+
+Request observado desde cliente y tests:
+
+```json
+{
+  "userId": 1,
+  "name": "Cliente",
+  "email": "cliente@example.com",
+  "address": "Calle 123",
+  "city": "Bogota",
+  "country": "Colombia",
+  "postalCode": "110111",
+  "phone": "3001234567",
+  "paymentMethod": "tarjeta",
+  "items": [
+    {
+      "productId": 10,
+      "quantity": 1,
+      "price": 120000
+    }
+  ]
+}
+```
+
+Respuesta exitosa de alto nivel observada:
+
+```json
+{
+  "success": true,
+  "order": {
+    "id": 1,
+    "total": 120000,
+    "status": "pendiente"
+  }
+}
+```
+
+Nota critica:
+
+- el backend recalcula `total` desde base de datos
+- el request todavia admite `userId` y no exige token en la ruta
+- esta es la principal tension entre `develop` y el criterio expresado en el review de PR `#17`
+
+## 4. Formatos de error actuales
+
+### Estandar central disponible
+
+`server/src/middlewares/errorHandler.ts` expone este formato base:
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Mensaje",
+    "statusCode": 400
+  }
+}
+```
+
+### Formatos legacy observados
+
+- auth manual: `{"error": "..."}`
+- cart mixto: `{"success": false, "error": "..."}`
+- orders manual: `{"success": false, "message": "..."}`
+- order reference errors: `{"success": false, "code": "...", "message": "..."}`
+
+### Casos relevantes ya corregidos
+
+- registro duplicado ya no debe documentarse como `409`; hoy el contrato observado es `400` generico
+- login usa mensaje homogeneo para credenciales invalidas
+- validaciones Zod que pasan por middleware usan el `errorHandler`
+
+## 5. Decisiones pendientes o brechas activas
+
+- El review de la PR `#17` pide definir un formato unico de error basado en `errorHandler`; `develop` todavia no lo aplica en todos los modulos.
+- `POST /api/orders` no puede documentarse hoy como endpoint autenticado estricto porque su implementacion y sus tests contradicen esa lectura.
+- README historico y contratos viejos que mencionen `409` en registro deben considerarse desactualizados.
+
+## 6. Propuesta de estandarizacion futura
+
+- Estandar sugerido para toda la API:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "MACHINE_CODE",
+    "message": "Mensaje legible",
+    "statusCode": 400,
+    "details": null
+  }
+}
+```
+
+- Tratar como `legacy` todos los formatos distintos mientras el backend no se unifique.
+- Publicar una tabla de codigos de error por modulo cuando se converja el contrato.

--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -1,0 +1,98 @@
+# Diagramas de arquitectura
+
+## 1. Estado actual observado en develop
+
+El sistema esta organizado como frontend React/Vite y backend Express/Prisma, con JWT para sesion, admin por rol y logica de compra repartida entre carrito, checkout y ordenes.
+
+## 2. Evidencia concreta
+
+- App backend: `server/src/app.ts`
+- Auth y JWT: `server/src/config/jwt.ts`, `server/src/middlewares/auth.ts`
+- Carrito: `server/src/routes/cart.ts`
+- Ordenes: `server/src/routes/orders.ts`, `server/src/controllers/orderController.ts`
+- Inventario: `server/src/services/inventoryService.ts`
+- Cliente API: `client/src/services/api.ts`
+- Rutas frontend: `client/src/routes/AppRoutes.tsx`
+
+## 3. Diagramas actuales
+
+### Componentes principales
+
+```text
+React/Vite client
+  -> AppRoutes guards
+  -> services/api.ts
+  -> localStorage session
+  -> pages Cart / Checkout / Admin
+
+Express API
+  -> app.ts mounts routes
+  -> auth routes/controllers
+  -> cart routes with inventory reservation
+  -> orders route/controller
+  -> admin routes with role checks
+  -> validation and error middlewares
+
+Prisma/PostgreSQL
+  -> User / Cart / CartItem
+  -> Product / ProductVariant / Category
+  -> Order / OrderItem
+```
+
+### Flujo de sesion
+
+```text
+POST /api/auth/login or /api/auth/register
+  -> controller validates credentials
+  -> generateToken({ id, email, role })
+  -> client stores token and user in localStorage
+  -> authApi adds Authorization header on authenticated requests
+```
+
+### Flujo actual de compra
+
+```text
+Catalog/ProductDetail
+  -> POST /api/cart/items
+  -> cart reserves stock atomically
+
+Cart
+  -> PATCH or DELETE /api/cart/items/:id
+  -> backend adjusts stock delta or restore
+
+Checkout frontend
+  -> guarded route in AppRoutes
+  -> createOrderRequest via authApi
+
+POST /api/orders backend
+  -> validates payload
+  -> tries req.userId or JWT if present
+  -> if not, can resolve by payload.userId or email
+  -> restores reserved cart stock
+  -> recalculates total from DB prices
+  -> decrements authoritative stock
+  -> creates order and clears cart
+```
+
+### Flujo admin
+
+```text
+Admin route in frontend
+  -> RequireAdmin guard
+  -> /api/admin/*
+  -> authenticateToken + authorizeRole([ADMIN])
+```
+
+## 4. Decisiones pendientes o brechas activas
+
+- El flujo de compra no esta plenamente alineado entre capas:
+  - frontend: checkout autenticado
+  - backend: `POST /api/orders` todavia admite resolucion sin token
+- El review de la PR `#17` pide usar la solucion segura como arquitectura canonica; `develop` actual solo la cumple parcialmente en ordenes.
+- La arquitectura actual no tiene un modulo unificado para politica de totales; carrito, checkout y orden persisten calculos distintos.
+
+## 5. Propuesta de estandarizacion futura
+
+- Consolidar el flujo de compra en una arquitectura con ownership de usuario unico y validado por token.
+- Unificar calculo de totales en una capa compartida o explicitamente canonica.
+- Publicar estos diagramas como anexo de arquitectura viva del proyecto, no como foto de un sprint historico.

--- a/docs/auth-session.md
+++ b/docs/auth-session.md
@@ -1,0 +1,106 @@
+# Autenticacion y sesion
+
+## 1. Estado actual observado en develop
+
+La aplicacion usa JWT con almacenamiento en frontend y rutas protegidas tanto en cliente como en backend, pero el flujo de ordenes conserva una brecha de consistencia.
+
+Comportamiento observado:
+
+- Login y registro devuelven `token` y `user`.
+- El JWT contiene `id`, `email` y `role`.
+- El frontend guarda usuario y token en `localStorage`.
+- Las guards del frontend protegen rutas de cliente y admin usando `getAuth()`.
+- El backend espera `Authorization: Bearer <token>` para rutas protegidas.
+- `GET /api/orders` requiere token.
+- `POST /api/orders` no exige `authenticateToken`, aunque el frontend lo llama como request autenticada.
+
+## 2. Evidencia concreta
+
+- JWT y expiracion: `server/src/config/jwt.ts`
+- Login: `server/src/controllers/authControllerLogin.ts`
+- Registro: `server/src/controllers/authControllerRegister.ts`
+- Middleware auth: `server/src/middlewares/auth.ts`
+- Rutas auth: `server/src/routes/auth.ts`
+- Rutas cliente/admin: `client/src/routes/AppRoutes.tsx`
+- Almacenamiento local: `client/src/utils/auth.ts`
+- Interceptor Axios: `client/src/services/api.ts`
+- Proteccion de rutas sin token: `server/tests/api/route-protections.api.test.ts`
+- Contexto de intencion del equipo: PRs `#14`, `#16` y review de PR `#17`
+
+## 3. Flujo actual documentado
+
+### Emision del token
+
+- `POST /api/auth/register` crea usuario `CLIENT` y devuelve JWT.
+- `POST /api/auth/login` devuelve JWT cuando email y password son validos.
+- `JWT_EXPIRY` usa `process.env.JWT_EXPIRY` o `7d` por defecto.
+- En `NODE_ENV=test` existe fallback a `test-secret-key`; fuera de test, `JWT_SECRET` es obligatorio.
+
+### Payload del token
+
+Campos observados:
+
+- `id`
+- `email`
+- `role`
+
+### Persistencia en frontend
+
+- Usuario serializado en `localStorage` con clave `vibe-pulse-auth`.
+- Token en `localStorage` con clave `vibe-pulse-token`.
+- `authApi` agrega `Authorization` automaticamente en requests autenticadas.
+
+### Rutas protegidas en frontend
+
+Invitado solamente:
+
+- `/login`
+- `/register`
+
+Usuario autenticado:
+
+- `/home`
+- `/catalogo`
+- `/products/:id`
+- `/cart`
+- `/checkout`
+- `/processing-payment`
+- `/purchase-alert`
+- `/confirmation`
+
+Administrador autenticado:
+
+- `/admin`
+- `/admin/products`
+- `/admin/orders`
+- `/admin/users`
+- `/admin/settings`
+
+### Rutas protegidas en backend
+
+- `/api/auth/me`
+- `/api/auth/profile`
+- `/api/auth/admin-only`
+- `/api/cart/*` por montaje con `authenticateToken` en `server/src/app.ts`
+- `/api/admin/*` por `router.use(authenticateToken, authorizeRole(["ADMIN"]))`
+- `GET /api/orders`
+
+### Mitigaciones de seguridad vigentes
+
+- Login usa hash dummy para reducir timing leak cuando el usuario no existe.
+- Registro devuelve `400` con mensaje generico ante email duplicado, alineado con la correccion de user enumeration pedida en PR `#14`.
+
+## 4. Decisiones pendientes o brechas activas
+
+- El review de la PR `#17` pide tratar ordenes como flujo `100%` autenticado; `develop` actual no cumple esa condicion porque `POST /api/orders` sigue sin `authenticateToken`.
+- `server/src/controllers/orderController.ts` todavia puede resolver identidad desde `userId` o `email` cuando no hay token.
+- Las guards del frontend validan presencia de sesion local, no validez criptografica en tiempo real.
+- No existe refresh token.
+- No existe rutina global de logout automatico ante `401`.
+
+## 5. Propuesta de estandarizacion futura
+
+- Formalizar una politica unica de sesion: almacenamiento, expiracion, renovacion y UX ante `401`.
+- Alinear `POST /api/orders` con el mismo modelo de autenticacion que ya usa el frontend, o documentarlo explicitamente como excepcion transitoria mientras siga abierto.
+- Publicar una tabla unica de rutas publicas, autenticadas y administrativas para QA y desarrollo.
+- Si se mantiene `localStorage`, dejarlo como decision explicita de implementacion actual y no como recomendacion de seguridad general.

--- a/docs/business-rules-cart-order-payment.md
+++ b/docs/business-rules-cart-order-payment.md
@@ -1,0 +1,93 @@
+# Reglas de carrito, checkout, orden y pago
+
+## 1. Estado actual observado en develop
+
+El sistema actual ya no esta en estado de Sprint 1. `develop` muestra un flujo de compra con carrito persistente, checkout protegido en frontend, stock atomico y recalculo autoritativo de precios. Al mismo tiempo, conserva una brecha importante en la autenticacion efectiva de `POST /api/orders`.
+
+## 2. Evidencia concreta
+
+- Carrito e inventario: `server/src/routes/cart.ts`
+- Servicio de stock atomico: `server/src/services/inventoryService.ts`
+- Ordenes y recalculo de total: `server/src/controllers/orderController.ts`
+- Rutas de orden: `server/src/routes/orders.ts`
+- Checkout frontend: `client/src/pages/Checkout.tsx`
+- Resumen visual del carrito: `client/src/pages/Cart.tsx`
+- Cliente API: `client/src/services/api.ts`
+- Tipos y schema de checkout: `client/src/types/checkout.ts`, `client/src/schemas/checkoutSchema.ts`
+- Pruebas de ordenes: `server/tests/api/orders.api.test.ts`
+- Proteccion de rutas: `server/tests/api/route-protections.api.test.ts`
+- PR `#14`: endurecimiento de inventario, precios y seguridad
+- PR `#18`: estado final actual de pruebas y ordenes en `develop`
+
+## 3. Reglas observadas
+
+### Carrito
+
+- Cada usuario autenticado opera sobre un carrito persistente por `userId`.
+- Si el carrito no existe, el backend lo crea con `upsert`.
+- El backend consolida lineas repetidas usando `lineKey` con `productId`, `variantId`, `color` y `size`.
+- `quantity` debe ser entero positivo y se valida por Zod.
+- El total del carrito se recalcula desde los subtotales persistidos de `CartItem`.
+
+### Inventario
+
+- Al agregar al carrito, el backend intenta reservar stock de forma atomica.
+- Si el item tiene `variantId`, opera sobre `ProductVariant.stock`.
+- Si no tiene `variantId`, opera sobre `Product.stock`.
+- Al aumentar cantidad se descuenta solo el delta.
+- Al disminuir cantidad o eliminar item se repone stock del recurso correspondiente.
+- Este comportamiento coincide con la intencion aprobada en PR `#14`.
+
+### Checkout
+
+- El frontend no deja confirmar una compra con carrito vacio.
+- El formulario recoge nombre, email, direccion, ciudad, pais, codigo postal, telefono y metodo de pago.
+- Los metodos visibles siguen siendo `tarjeta` y `paypal`.
+- PayPal es flujo simulado de interfaz, no integracion real de pasarela.
+- Existe cupon simulado `VIBRA10` que afecta solo el calculo visual del frontend.
+
+### Ordenes
+
+- `createOrder` normaliza items por `productId` + `variantId`.
+- El backend busca los productos en base de datos y recalcula el total usando `product.price`.
+- El `price` enviado por el cliente ya no gobierna el total final de la orden.
+- Si hay `variantId`, la creacion de orden usa `decrementVariantStock(...)`.
+- Si no hay `variantId`, usa `decrementProductStock(...)`.
+- Si el usuario tiene carrito, la orden restaura primero el stock reservado en carrito y luego vuelve a descontar el stock autoritativo en la orden.
+- Tras crear la orden, el carrito se vacia y su `total` queda en `0`.
+
+### Estados de orden
+
+Estado inicial observado:
+
+- `pendiente`
+
+Estados aceptados hoy por validacion admin:
+
+- `pendiente`
+- `pagado`
+- `enviado`
+- `entregado`
+- `cancelado`
+
+## 4. Decisiones pendientes o brechas activas
+
+- El review de la PR `#17` pide documentar checkout como `100%` autenticado. `develop` actual no cumple eso en backend:
+  - `client/src/services/api.ts` llama `POST /api/orders` con token
+  - `client/src/routes/AppRoutes.tsx` protege `/checkout`
+  - `server/src/routes/orders.ts` deja `POST /api/orders` sin `authenticateToken`
+  - `server/src/controllers/orderController.ts` todavia admite `userId` del cliente o resolucion por email y puede crear usuario placeholder
+- El PDF QA clasifica `POST /api/orders` y `GET /api/orders` como autenticados. Hoy solo `GET /api/orders` lo cumple en codigo y en tests de proteccion.
+- `server/tests/api/orders.api.test.ts` consolida el contrato actual de `develop` para crear orden sin token usando `userId`.
+- El frontend y el backend no usan la misma formula de total:
+  - `client/src/pages/Cart.tsx` aplica envio e impuestos
+  - `client/src/pages/Checkout.tsx` aplica envio gratis y cupon simulado
+  - `server/src/controllers/orderController.ts` solo persiste suma autoritativa de items
+- `OrderItem` no guarda `variantId`, aunque el descuento de stock si usa variante cuando existe.
+
+## 5. Propuesta de estandarizacion futura
+
+- Unificar el contrato de ownership de orden: autenticado estricto o excepcion transitoria explicitamente documentada.
+- Publicar una sola formula oficial de subtotal, envio, impuestos, descuentos y total.
+- Si las variantes son parte estable del checkout, persistir snapshot suficiente de variante en `OrderItem`.
+- Definir estados de orden y transiciones como contrato de negocio formal, no solo como lista de valores admitidos.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,222 @@
+# Modelo de datos
+
+## 1. Estado actual observado en develop
+
+El modelo fuente del sistema esta en `server/prisma/schema.prisma`.
+
+Entidades observadas:
+
+- `User`
+- `Category`
+- `Product`
+- `ProductVariant`
+- `Cart`
+- `CartItem`
+- `Order`
+- `OrderItem`
+- enum `Role`
+
+Reglas estructurales observadas:
+
+- `User.email` es unico y `User.role` usa `Role` con `CLIENT` y `ADMIN`.
+- `Cart.userId` es unico, por lo que el modelo soporta un carrito persistente por usuario.
+- `CartItem` consolida lineas con `@@unique([cartId, lineKey])`.
+- `ProductVariant` depende de `Product` y participa en carrito, pero no tiene tabla propia en `OrderItem`.
+- `Order.status` no usa enum Prisma; hoy es `String` con default `pendiente`.
+- `OrderItem` guarda `productId`, `quantity` y `price`, pero no `variantId`.
+
+## 2. Evidencia concreta
+
+- Modelo Prisma base: `server/prisma/schema.prisma`
+- Stock atomico por producto y variante: `server/src/services/inventoryService.ts`
+- Consolidacion de carrito por `lineKey`: `server/src/routes/cart.ts`
+- Ordenes con recalculo autoritativo y descuento de stock: `server/src/controllers/orderController.ts`
+- Estados aceptados por validacion admin: `server/src/middlewares/validation.ts`
+- PR `#14`: valida la introduccion de control autoritativo de precio e inventario
+- PR `#18`: consolida en `develop` el estado final actual del flujo de ordenes
+
+## 3. Modelo documentado
+
+### `Role`
+
+Valores observados:
+
+- `CLIENT`
+- `ADMIN`
+
+### `User`
+
+Campos observados:
+
+- `id: Int`
+- `name: String`
+- `email: String @unique`
+- `password: String`
+- `role: Role = CLIENT`
+- `createdAt: DateTime`
+- `updatedAt: DateTime`
+
+Relaciones:
+
+- `cart: Cart?`
+- `orders: Order[]`
+
+### `Category`
+
+Campos observados:
+
+- `id: Int`
+- `name: String @unique`
+- `slug: String @unique`
+- `imageUrl: String?`
+- `description: String?`
+- `createdAt: DateTime`
+
+Relaciones:
+
+- `products: Product[]`
+
+### `Product`
+
+Campos observados:
+
+- `id: Int`
+- `name: String`
+- `description: String?`
+- `price: Float`
+- `comparePrice: Float?`
+- `imageUrl: String`
+- `stock: Int = 0`
+- `featured: Boolean = false`
+- `badge: String?`
+- `categoryId: Int`
+- `createdAt: DateTime`
+- `updatedAt: DateTime`
+
+Relaciones:
+
+- `category: Category`
+- `variants: ProductVariant[]`
+- `cartItems: CartItem[]`
+- `orderItems: OrderItem[]`
+
+Indices observados:
+
+- `@@index([categoryId])`
+- `@@index([name])`
+
+### `ProductVariant`
+
+Campos observados:
+
+- `id: Int`
+- `name: String`
+- `color: String?`
+- `size: String?`
+- `price: Float`
+- `stock: Int`
+- `productId: Int`
+
+Relaciones:
+
+- `product: Product`
+- `cartItems: CartItem[]`
+
+Observacion:
+
+- La variante participa en carrito y en el decremento de stock de orden, pero el snapshot persistido en `OrderItem` no guarda `variantId`.
+
+### `Cart`
+
+Campos observados:
+
+- `id: Int`
+- `userId: Int @unique`
+- `total: Float = 0`
+- `createdAt: DateTime`
+- `updatedAt: DateTime`
+
+Relaciones:
+
+- `user: User`
+- `items: CartItem[]`
+
+### `CartItem`
+
+Campos observados:
+
+- `id: Int`
+- `cartId: Int`
+- `productId: Int`
+- `variantId: Int?`
+- `lineKey: String`
+- `color: String?`
+- `size: String?`
+- `quantity: Int = 1`
+- `unitPrice: Float`
+- `subtotal: Float`
+- `createdAt: DateTime`
+- `updatedAt: DateTime`
+
+Relaciones:
+
+- `cart: Cart`
+- `product: Product`
+- `variant: ProductVariant?`
+
+Restricciones observadas:
+
+- `@@unique([cartId, lineKey])`
+- `onDelete: Cascade` sobre `cart`
+
+### `Order`
+
+Campos observados:
+
+- `id: Int`
+- `userId: Int`
+- `email: String`
+- `total: Float`
+- `status: String = "pendiente"`
+- `name: String`
+- `address: String`
+- `city: String`
+- `country: String`
+- `postalCode: String`
+- `phone: String`
+- `paymentMethod: String`
+- `createdAt: DateTime`
+
+Relaciones:
+
+- `user: User`
+- `items: OrderItem[]`
+
+### `OrderItem`
+
+Campos observados:
+
+- `id: Int`
+- `orderId: Int`
+- `productId: Int`
+- `quantity: Int`
+- `price: Float`
+
+Relaciones:
+
+- `order: Order`
+- `product: Product`
+
+## 4. Decisiones pendientes o brechas activas
+
+- `Order.status` sigue como `String`; el PDF QA esperaba definicion formal de estados y transiciones.
+- `OrderItem` no persiste `variantId`, aunque la orden si descuenta stock por variante cuando aplica.
+- El review de la PR `#17` pedia usar la solucion segura como contrato canonico; `develop` actual si refleja precio autoritativo y stock atomico, pero no cierra del todo la historia de ownership de orden.
+- No hay snapshot explicito de nombre de variante, color o talla en `OrderItem`; el detalle historico de compra depende del producto base.
+
+## 5. Propuesta de estandarizacion futura
+
+- Convertir `Order.status` a enum Prisma para alinear base, validacion y admin.
+- Evaluar agregar `variantId` o snapshot de variante en `OrderItem` para trazabilidad historica.
+- Definir si `Order` debe modelar descuentos, envio e impuestos como campos propios, ya que hoy solo persiste `total`.
+- Publicar este modelo como contrato de referencia del equipo para evitar divergencias entre frontend, backend y QA.

--- a/docs/permissions-and-env.md
+++ b/docs/permissions-and-env.md
@@ -1,0 +1,96 @@
+# Permisos y entorno
+
+## 1. Estado actual observado en develop
+
+La aplicacion combina permisos por rol, proteccion por token y configuracion por variables de entorno para auth, CORS y rate limiting.
+
+## 2. Evidencia concreta
+
+- App y montaje de rutas: `server/src/app.ts`
+- Auth y roles: `server/src/middlewares/auth.ts`
+- Rutas admin: `server/src/routes/admin.ts`
+- Rate limiting: `server/src/middlewares/rateLimiter.ts`
+- Variables de ejemplo: `server/.env.example`
+- Cliente API base: `client/src/services/api.ts`
+- Guards frontend: `client/src/routes/AppRoutes.tsx`
+
+## 3. Permisos actuales
+
+### Publico
+
+- `GET /api/health`
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- catalogo y categorias por lectura
+- `POST /api/orders` en backend actual
+
+### Usuario autenticado
+
+- `/home`, `/catalogo`, `/products/:id`, `/cart`, `/checkout` y rutas relacionadas en frontend
+- `/api/auth/me`
+- `/api/auth/profile`
+- `/api/cart/*`
+- `GET /api/orders`
+
+### Administrador
+
+- `/admin` y subrutas frontend
+- `/api/auth/admin-only`
+- `/api/admin/*`
+- mutaciones admin de productos y categorias
+
+## 4. Variables de entorno observadas
+
+### Backend
+
+- `DATABASE_URL`
+- `PORT`
+- `JWT_SECRET`
+- `JWT_EXPIRY`
+- `CLIENT_ORIGIN`
+- `ADMIN_SEED_PASSWORD`
+- `CLIENT_SEED_PASSWORD`
+- `RATE_LIMIT_MAX_REQUESTS`
+- `RATE_LIMIT_WINDOW_MS`
+- `AUTH_RATE_LIMIT_MAX_REQUESTS`
+- `AUTH_RATE_LIMIT_WINDOW_MS`
+- `TRUST_PROXY_HOPS`
+
+### Variables leidas en app pero no visibles en `.env.example`
+
+- `ALLOWED_ORIGINS`
+- `ALLOWED_ORIGIN_PATTERNS`
+
+Observacion:
+
+- `server/src/app.ts` ya soporta esas variables para CORS, pero `server/.env.example` todavia no las documenta.
+
+### Frontend
+
+- `VITE_API_URL`
+
+Comportamiento observado:
+
+- si no existe `VITE_API_URL`, el cliente usa `http://localhost:3000`
+
+## 5. Rate limiting actual
+
+- `development`: minimo `1000` requests por ventana y bypass para `127.0.0.1`, `::1`, `::ffff:127.0.0.1`
+- `production`: usa los limites configurados
+- `authRateLimiter` reutiliza el mismo middleware con parametros distintos
+
+Contexto de equipo:
+
+- PR `#16` valido este ajuste por ambiente como nueva base tecnica para QA de rendimiento local
+
+## 6. Decisiones pendientes o brechas activas
+
+- `AUTH_RATE_LIMIT_MAX_REQUESTS` y `AUTH_RATE_LIMIT_WINDOW_MS` en `.env.example` aparecen hoy con `100/120000`, mientras comentarios historicos del repo hablan de `5/15m`; la documentacion debe reflejar el estado actual y no el comentario viejo.
+- `ALLOWED_ORIGINS` y `ALLOWED_ORIGIN_PATTERNS` necesitan documentacion explicita en el ejemplo de entorno para evitar configuraciones parciales.
+- `POST /api/orders` sigue publico en backend actual; por eso no puede incluirse en la matriz de permisos como autenticado estricto.
+
+## 7. Propuesta de estandarizacion futura
+
+- Alinear `server/.env.example`, README y despliegue con todas las variables realmente soportadas.
+- Publicar una matriz unica de permisos por ruta y rol como referencia operativa del equipo.
+- Revisar si el bypass de rate limiting en `development` debe convivir con una configuracion diferenciada para `test` si el proyecto crece.

--- a/docs/traceability-matrix.md
+++ b/docs/traceability-matrix.md
@@ -1,0 +1,43 @@
+# Matriz de trazabilidad
+
+## 1. Estado actual observado en develop
+
+Esta matriz cubre `QA-019` sobre el estado real de `origin/develop`. Se enlazan requisitos operativos observables con frontend, backend, pruebas y contexto de PRs aceptadas cuando ayudan a entender la intencion del equipo.
+
+## 2. Evidencia concreta
+
+- Rutas y protecciones: `server/src/app.ts`, `server/src/routes/*.ts`
+- Controllers y middlewares: `server/src/controllers/*.ts`, `server/src/middlewares/*.ts`
+- Frontend y guards: `client/src/routes/AppRoutes.tsx`, `client/src/services/api.ts`, `client/src/utils/auth.ts`
+- Pruebas API: `server/tests/api/route-manifest.contract.test.ts`, `server/tests/api/route-protections.api.test.ts`, `server/tests/api/orders.api.test.ts`
+- Contexto de seguridad y consistencia: PRs `#14`, `#16` y `#18`
+
+## 3. Matriz
+
+| ID | Requisito operativo | Evidencia frontend | Evidencia backend | Evidencia en tests | Estado actual |
+| --- | --- | --- | --- | --- | --- |
+| RF-AUTH-001 | Un usuario puede registrarse con nombre, email y password | `client/src/services/api.ts` | `server/src/routes/auth.ts`, `server/src/controllers/authControllerRegister.ts` | `server/tests/api/route-protections.api.test.ts` | implementado |
+| RF-AUTH-002 | Un usuario puede iniciar sesion y recibir JWT | `client/src/services/api.ts`, `client/src/utils/auth.ts` | `server/src/routes/auth.ts`, `server/src/controllers/authControllerLogin.ts`, `server/src/config/jwt.ts` | `server/tests/api/route-protections.api.test.ts` | implementado |
+| RF-AUTH-003 | Un usuario autenticado puede consultar su identidad | consumo disponible desde cliente API | `server/src/routes/auth.ts`, `server/src/middlewares/auth.ts` | `server/tests/api/route-protections.api.test.ts` | implementado |
+| RF-AUTH-004 | Solo un admin puede acceder al backoffice | `client/src/routes/AppRoutes.tsx` | `server/src/routes/admin.ts`, `server/src/middlewares/auth.ts` | `server/tests/api/route-protections.api.test.ts` | implementado |
+| RF-CART-001 | Un usuario autenticado puede consultar su carrito | `client/src/pages/Cart.tsx`, `client/src/services/api.ts` | `server/src/app.ts`, `server/src/routes/cart.ts` | `server/tests/api/route-protections.api.test.ts`, `server/tests/api/route-manifest.contract.test.ts` | implementado |
+| RF-CART-002 | Un usuario autenticado puede agregar items al carrito con validacion y reserva de stock | `client/src/services/api.ts` | `server/src/routes/cart.ts`, `server/src/services/inventoryService.ts` | `server/tests/api/route-protections.api.test.ts`, contexto PR `#14` | implementado |
+| RF-CART-003 | Un usuario autenticado puede editar o eliminar items y el stock se ajusta por delta | `client/src/pages/Cart.tsx` | `server/src/routes/cart.ts`, `server/src/services/inventoryService.ts` | `server/tests/api/route-protections.api.test.ts` | implementado |
+| RF-ORDER-001 | El frontend de checkout opera como flujo autenticado | `client/src/routes/AppRoutes.tsx`, `client/src/pages/Checkout.tsx`, `client/src/services/api.ts` | sin paridad total en `POST /api/orders` | sin prueba dedicada de proteccion en POST | parcial |
+| RF-ORDER-002 | El sistema puede crear una orden con precio autoritativo e inventario atomico | `client/src/pages/Checkout.tsx`, `client/src/services/api.ts` | `server/src/controllers/orderController.ts`, `server/src/services/inventoryService.ts` | `server/tests/api/orders.api.test.ts`, contexto PR `#14` | implementado con brecha de auth |
+| RF-ORDER-003 | Un usuario autenticado puede listar sus ordenes | sin pantalla cliente dedicada fuera del flujo general | `server/src/routes/orders.ts`, `server/src/controllers/orderController.ts` | `server/tests/api/route-protections.api.test.ts`, `server/tests/api/route-manifest.contract.test.ts` | implementado |
+| RF-ADMIN-001 | Un admin puede consultar metricas, usuarios y pedidos | `client/src/routes/AppRoutes.tsx`, modulos admin lazy | `server/src/routes/admin.ts` | `server/tests/api/route-protections.api.test.ts`, `server/tests/api/route-manifest.contract.test.ts` | implementado |
+| RF-ADMIN-002 | Un admin puede mutar productos y categorias | `client/src/services/api.ts` | `server/src/routes/products.ts`, `server/src/routes/categories.ts` | `server/tests/api/route-protections.api.test.ts`, `server/tests/api/route-manifest.contract.test.ts` | implementado |
+
+## 4. Decisiones pendientes o brechas activas
+
+- `RF-ORDER-001` sigue parcial porque frontend y backend no comparten el mismo contrato de autenticacion para crear orden.
+- La matriz puede enlazar la intencion de PR `#14`, pero no debe presentar esa intencion como cumplimiento pleno mientras `develop` mantenga `POST /api/orders` abierto.
+- Faltan casos de prueba de proteccion especificos para `POST /api/orders` sin token, justamente porque el contrato actual en `develop` no lo rechaza.
+- Varias evidencias de admin son contractuales por ruta y proteccion, no por flujos E2E detallados del bloque.
+
+## 5. Propuesta de estandarizacion futura
+
+- Asociar cada requisito a IDs de caso de prueba estables en API, unit, component y E2E.
+- Agregar casos dedicados para cerrar o confirmar la brecha de autenticacion en ordenes.
+- Mantener esta matriz como anexo vivo del proceso QA para que review, codigo y pruebas usen el mismo lenguaje.


### PR DESCRIPTION
## Objetivo
Rehacer la documentacion de la issue #12 (`Bloque 5 QA - Requisitos, diseño, trazabilidad y documentación técnica`) tomando `develop` como fuente principal del estado actual del sistema.

## Qué se hizo
- se recreó la documentación del Bloque 5 en `docs/`
- se documentó `QA-016` a `QA-020` con estructura uniforme:
  - estado actual observado en `develop`
  - evidencia concreta
  - brechas activas
  - propuesta de estandarización futura
- se actualizó `README.md` para reflejar el alcance actual del sistema
- se marcó `INTEGRACION-SPRINT3.md` como referencia histórica

## Criterio aplicado
- `develop` se usó como fuente principal del estado actual
- PRs #14, #16 y #18 se usaron como contexto de intención y validación del equipo
- cuando el review de PR #17 no coincide exactamente con `develop`, la diferencia se documenta como brecha abierta

## Hallazgos clave documentados
- registro con `400` genérico para evitar user enumeration
- mitigación de timing leak en login
- inventario con operaciones atómicas por producto o variante
- recalculo autoritativo de precios en órdenes
- brecha abierta de autenticación en `POST /api/orders`
- falta de estandar único de errores API
- diferencias activas entre frontend, backend y contrato final esperado en órdenes

## Archivos principales
- `docs/README.md`
- `docs/data-model.md`
- `docs/auth-session.md`
- `docs/business-rules-cart-order-payment.md`
- `docs/traceability-matrix.md`
- `docs/api-contracts-and-errors.md`
- `docs/permissions-and-env.md`
- `docs/architecture-diagrams.md`
- `README.md`
- `INTEGRACION-SPRINT3.md`

## Validación
- contraste manual contra issue #12
- contraste con el review principal de PR #17
- revisión de PRs #14, #16 y #18
- revisión del PDF QA usado como contexto
- revisión de código y tests actuales en `develop`

## Notas
- No se cambió lógica funcional.
- No se modificaron endpoints ni tests.
- El PDF QA usado como contexto de trabajo no fue incluido en el commit.